### PR TITLE
netdes: add average_scenario_creator for Jensen's bound

### DIFF
--- a/examples/netdes/netdes.py
+++ b/examples/netdes/netdes.py
@@ -21,23 +21,32 @@ import numpy as np
 from parse import parse
 
 
-def scenario_creator(scenario_name, path=None):
-    if path is None:
-        raise RuntimeError('Must provide the name of the .dat file '
-                           'containing the instance data via the '
-                           'path argument to scenario_creator')
-    
-    scenario_ix = _get_scenario_ix(scenario_name)
-    model = build_scenario_model(path, scenario_ix)
+# ===========================================================================
+# Underscore helpers (best-practice pattern -- see doc/src/jensens.rst):
+#
+#   _scenario_data : pure-Python data dict for one scenario, no Pyomo
+#   _build_model   : build the Pyomo model from a data dict
+#
+# scenario_creator and average_scenario_creator both go through these
+# helpers so the model-build code lives in exactly one place.
+# ===========================================================================
 
-    # now attach the one and only scenario tree node
-    sputils.attach_root_node(model, model.FirstStageCost, [model.x[:,:], ])
-    
-    return model
+def _scenario_data(scenario_ix, path):
+    """Return the full data dict for one scenario as plain Python.
+
+    Thin wrapper over parse(...) so scenario_creator and
+    average_scenario_creator share the same data-loading entry point.
+    """
+    return parse(path, scenario_ix=scenario_ix)
 
 
-def build_scenario_model(fname, scenario_ix):
-    data = parse(fname, scenario_ix=scenario_ix)
+def _build_model(data, probability):
+    """Build the network-design Pyomo model from a data dict.
+
+    Shared by scenario_creator and average_scenario_creator. The dict
+    must have keys N, A, el, c, d, u, b (the first four are
+    deterministic; d, u, b are the second-stage stochastic data).
+    """
     num_nodes = data['N']
     adj = data['A']    # Adjacency matrix
     edges = data['el'] # Edge list
@@ -45,14 +54,13 @@ def build_scenario_model(fname, scenario_ix):
     d = data['d']      # Second-stage cost matrix (per edge)
     u = data['u']      # Capacity of each arc
     b = data['b']      # Demand of each node
-    p = data['p']      # Probability of scenario
 
     model = pyo.ConcreteModel()
     model.x = pyo.Var(edges, domain=pyo.Binary)           # First stage vars
     model.y = pyo.Var(edges, domain=pyo.NonNegativeReals) # Second stage vars
 
     model.edges = edges
-    model._mpisppy_probability = p
+    model._mpisppy_probability = probability
 
     ''' Objective '''
     model.FirstStageCost  = pyo.quicksum(c[e] * model.x[e] for e in edges)
@@ -63,7 +71,7 @@ def build_scenario_model(fname, scenario_ix):
     ''' Variable upper bound constraints on each edge '''
     model.vubs = pyo.ConstraintList()
     for e in edges:
-        expr = model.y[e] - u[e] * model.x[e] 
+        expr = model.y[e] - u[e] * model.x[e]
         model.vubs.add(expr <= 0)
 
     ''' Flow balance constraints for each node '''
@@ -75,6 +83,84 @@ def build_scenario_model(fname, scenario_ix):
               pyo.quicksum(model.y[j,i] for j in in_nbs)
         model.bals.add(lhs == b[i])
 
+    return model
+
+
+def scenario_creator(scenario_name, path=None):
+    if path is None:
+        raise RuntimeError('Must provide the name of the .dat file '
+                           'containing the instance data via the '
+                           'path argument to scenario_creator')
+
+    scenario_ix = _get_scenario_ix(scenario_name)
+    data = _scenario_data(scenario_ix, path)
+    model = _build_model(data, probability=data['p'])
+
+    # now attach the one and only scenario tree node
+    sputils.attach_root_node(model, model.FirstStageCost, [model.x[:,:], ])
+
+    return model
+
+
+def average_scenario_creator(scenario_name, path=None):
+    """Build the average scenario for ``--*-try-jensens-first``.
+
+    Constructs a single deterministic model whose second-stage data
+    (d, u, b) is the probability-weighted mean of the per-scenario
+    data shipped in the instance file. The first-stage data (c) and
+    network topology (N, A, el) are deterministic and copied through.
+    ``_mpisppy_probability`` is 1.0.
+
+    Every rank constructs an identical model independently. The
+    instance file is parsed once.
+
+    Jensen's-bound validity (see doc/src/jensens.rst):
+
+      * netdes has continuous recourse (``model.y`` is
+        ``NonNegativeReals``), so the integer-recourse guard on the
+        outer-bound path will pass.
+      * Randomness lives in the second-stage objective coefficients
+        ``d``, the per-arc capacity ``u`` (which appears in
+        ``y[e] - u[e]*x[e] <= 0``, i.e. as an effective RHS once x
+        is fixed), and the node demand RHS ``b``. RHS-only randomness
+        gives a recourse value that is convex in those parameters,
+        so the Jensen's outer bound is valid for randomness in
+        ``u`` and ``b``. Cost-coefficient randomness (``d``) makes
+        the recourse value concave in ``d``; users who require a
+        provably valid Jensen's *outer* bound should be aware of
+        this and decide whether the bound is meaningful for their
+        instance.
+      * The xhat (inner-bound) path is unaffected by the convexity
+        question -- it uses the average scenario only as a source of
+        a candidate first-stage x, which is then honestly evaluated
+        across all real scenarios.
+    """
+    if path is None:
+        raise RuntimeError('Must provide the name of the .dat file '
+                           'containing the instance data via the '
+                           'path argument to average_scenario_creator')
+
+    full = parse(path, scenario_ix=None)
+    K = full['K']
+    p = full['p']
+    # Probability-weighted mean across all scenarios. Netdes ships
+    # non-uniform probabilities in general, so this is NOT a simple
+    # arithmetic mean.
+    avg_d = sum(p[k] * full['d'][k] for k in range(K))
+    avg_u = sum(p[k] * full['u'][k] for k in range(K))
+    avg_b = sum(p[k] * full['b'][k] for k in range(K))
+
+    avg_data = {
+        'N': full['N'],
+        'A': full['A'],
+        'el': full['el'],
+        'c': full['c'],
+        'd': avg_d,
+        'u': avg_u,
+        'b': avg_b,
+    }
+    model = _build_model(avg_data, probability=1.0)
+    sputils.attach_root_node(model, model.FirstStageCost, [model.x[:,:], ])
     return model
 
 

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -134,7 +134,7 @@ def do_one_mmw(dirname, modname, runefstring, npyfile, mmwargstring):
     os.chdir("..")
     os.chdir("..")  # moved to CI directory
 
-# -------- First part: farmer family --------
+# -------- First part: farmer family, usar, netdes --------
 if run_first_part:
     do_one("farmer/CI", "farmer_ef.py", 1,
            "1 3 {}".format(solver_name))
@@ -218,8 +218,7 @@ if run_first_part:
            f"--max-iterations=3 --default-rho=1 --lagrangian --xhatshuffle "
            f"--output-dir=solutions_ws {usar_problem_args}")
 
-# -------- Second part: netdes, sizes, sslp, hydro, aircond, MMW --------
-if run_second_part:
+    # netdes
     # NOTE: Pyomo OBBT does not support persistent solvers as of Aug 2025
     direct_solver_name = solver_name.replace("_persistent", "_direct") if "_persistent" in solver_name else solver_name
     do_one("netdes", "netdes_cylinders.py", 4,
@@ -239,6 +238,22 @@ if run_second_part:
            "--subgradient-hub --xhatshuffle --max-solver-threads=2 "
            "--solver-name={}".format(solver_name))
 
+    # Smoke-test netdes's average_scenario_creator via --*-try-jensens-first.
+    # PH hub + lagrangian + xhatshuffle = 3 cylinders. The lagrangian spoke
+    # solves the average scenario before iter-0 and sends the result as its
+    # first outer bound; the xhatshuffle spoke uses the average scenario's
+    # first-stage solution as its first xhat candidate.
+    do_one("netdes", "../../mpisppy/generic_cylinders.py", 3,
+           "--module-name netdes --max-iterations=3 "
+           "--instance-name=network-10-20-L-01 --netdes-data-path ./data "
+           "--rel-gap=0.0 --default-rho=10000 --presolve "
+           "--lagrangian --xhatshuffle "
+           "--lagrangian-try-jensens-first --xhatshuffle-try-jensens-first "
+           "--max-solver-threads=2 "
+           "--solver-name={}".format(solver_name))
+
+# -------- Second part: sizes, sslp, hydro, aircond, MMW --------
+if run_second_part:
     # sizes is slow for xpress so try linearizing the proximal term.
     do_one("sizes",
            "sizes_cylinders.py",


### PR DESCRIPTION
## Summary

- Refactor `examples/netdes/netdes.py` along the §7 farmer pattern from `doc/jensens_bound_design.md`: split the old `build_scenario_model` into `_scenario_data` (thin wrapper over `parse`, returns dict) and `_build_model` (Pyomo). `scenario_creator` now goes through both; external behavior unchanged.
- Add `average_scenario_creator(scenario_name, path=None)` that probability-weighted-averages the second-stage data (`d`, `u`, `b`) across all scenarios in the instance file. Netdes ships **non-uniform** probabilities so this is *not* a simple arithmetic mean. Returns a model with `_mpisppy_probability=1.0`.
- Big docstring caveat on Jensen's-bound validity: `u` and `b` are RHS-only (clean Jensen's case) but `d` is an objective coefficient (Q is concave in `d`), so users need to think before flipping `--lagrangian-try-jensens-first`. The xhat path is unconditionally fine.
- `examples/run_all.py`: move all three netdes entries from second part → first part, since the second part is the long pole. Add a third netdes entry that smoke-tests the new code via `--lagrangian-try-jensens-first --xhatshuffle-try-jensens-first` through the generic driver. Header comments updated for both parts; `direct_solver_name` calculation moved with the OBBT-using entry.

sslp is **not** included here — it has integer recourse plus a Binary-typed stochastic param (`ClientPresent`), which needs a separate design discussion. Will be a follow-up PR.

## Test plan

- [x] `ruff check examples/netdes/netdes.py` passes
- [x] `examples/netdes/netdes.py` smoke: `scenario_creator('Scen3', path=...)` and `average_scenario_creator('avg', path=...)` both build; constraint counts match; average scenario has `_mpisppy_probability=1.0`
- [x] Average scenario LP solves with cplex on `network-10-10-L-01.dat` (objective 80788.39)
- [x] Full EF on the same instance solves to 88557.30 — average is below the EF optimum, consistent with Jensen's lower-bound theory for the convex (RHS-randomness) part of the recourse on this instance
- [x] `python -c "import ast; ast.parse(open('examples/run_all.py').read())"` parses
- [ ] Full `python examples/run_all.py <solver> --first-part-only` run (delegating to CI)