### PR TITLE
add feasible_xhat_creator convention for per-scenario-feasible candidates

### DIFF
--- a/examples/netdes/netdes_auxiliary.py
+++ b/examples/netdes/netdes_auxiliary.py
@@ -1,0 +1,74 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Auxiliary functions for the netdes example.
+
+Kept out of ``netdes.py`` so first-time readers of the introductory
+example are not confronted with helpers they do not need. Functions
+here are consumed by downstream tools (e.g. findW's pin-dual algorithm)
+that need a first-stage point feasible for every real scenario's
+per-scenario subproblem.
+"""
+
+import numpy as np
+
+from mpisppy.utils.xhat_helpers import lp_xbar_nonants
+from netdes import scenario_creator, scenario_names_creator
+
+
+def feasible_xhat_creator(
+    *,
+    solver_name,
+    solver_options=None,
+    num_scens=None,
+    **scenario_creator_kwargs,
+):
+    """Return a candidate first-stage x for netdes that is feasible to
+    fix in every real scenario's per-scenario subproblem.
+
+    Returns ``{"ROOT": np.ndarray}`` in
+    ``_mpisppy_node_list[0].nonant_vardata_list`` order, ready to pass
+    to ``Xhat_Eval._fix_nonants``.
+
+    Strategy: solve the LP relaxation of every real scenario, take the
+    probability-weighted average of arc-open values (the LP-xbar), and
+    apply ``np.ceil``. The recourse constraint is
+    ``y[e] - u[e]*x[e] <= 0``; raising ``x[e]`` to 1 only loosens this
+    bound, so opening more arcs never tightens any per-scenario
+    subproblem. Ceiling the LP-xbar opens every arc that any scenario's
+    LP wanted positive, producing a strict cover that is feasible
+    when pinned in every real scenario.
+
+    The small ``- 1e-9`` margin keeps integer-valued LP solutions from
+    being inadvertently bumped up by floating-point dust.
+
+    Args:
+        solver_name: pyomo solver name.
+        solver_options: solver options dict.
+        num_scens: number of real scenarios to aggregate over. If None,
+            it is read from the instance file via ``parse``.
+        **scenario_creator_kwargs: forwarded to
+            ``netdes.scenario_creator`` (notably ``path``).
+    """
+    if num_scens is None:
+        from parse import parse
+        path = scenario_creator_kwargs.get("path")
+        if path is None:
+            raise ValueError(
+                "feasible_xhat_creator needs num_scens or path kwarg"
+            )
+        num_scens = parse(path, scenario_ix=None)["K"]
+    snames = scenario_names_creator(num_scens)
+    arr = lp_xbar_nonants(
+        scenario_creator,
+        snames,
+        solver_name=solver_name,
+        scenario_creator_kwargs=scenario_creator_kwargs,
+        solver_options=solver_options,
+    )
+    return {"ROOT": np.ceil(arr - 1e-9)}

--- a/examples/sslp/sslp_auxiliary.py
+++ b/examples/sslp/sslp_auxiliary.py
@@ -1,0 +1,63 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Auxiliary functions for the sslp example.
+
+Kept out of ``sslp.py`` so first-time readers of the introductory
+example are not confronted with helpers they do not need. Functions
+here are consumed by downstream tools (e.g. findW's pin-dual algorithm)
+that need a first-stage point feasible for every real scenario's
+per-scenario subproblem.
+"""
+
+import numpy as np
+
+from mpisppy.utils.xhat_helpers import lp_xbar_nonants
+from sslp import scenario_creator, scenario_names_creator
+
+
+def feasible_xhat_creator(
+    *,
+    solver_name,
+    solver_options=None,
+    num_scens,
+    **scenario_creator_kwargs,
+):
+    """Return a candidate first-stage ``FacilityOpen`` for sslp.
+
+    Returns ``{"ROOT": np.ndarray}`` in
+    ``_mpisppy_node_list[0].nonant_vardata_list`` order.
+
+    Strategy: solve the LP relaxation of every real scenario, take the
+    probability-weighted average of ``FacilityOpen`` (sslp ships
+    ``_mpisppy_probability = "uniform"``), then ``np.round`` to
+    integer.
+
+    Why ``np.round`` is feasibility-preserving for sslp: more open
+    facilities never tightens ``DemandConstraint`` (more capacity) or
+    ``ClientConstraint`` (does not involve ``FacilityOpen``). The
+    shipped model also carries a high-``Penalty`` ``Dummy`` slack, so
+    any pin is technically feasible; the rounded LP-xbar is a
+    meaningful low-slack candidate for the pin-dual machinery.
+
+    Args:
+        solver_name: pyomo solver name.
+        solver_options: solver options dict.
+        num_scens: number of scenarios to aggregate over.
+        **scenario_creator_kwargs: forwarded to
+            ``sslp.scenario_creator`` (e.g. ``data_dir``, ``surrogate``).
+    """
+    snames = scenario_names_creator(num_scens)
+    arr = lp_xbar_nonants(
+        scenario_creator,
+        snames,
+        solver_name=solver_name,
+        scenario_creator_kwargs=scenario_creator_kwargs,
+        solver_options=solver_options,
+    )
+    return {"ROOT": np.round(arr)}

--- a/mpisppy/tests/test_feasible_xhat.py
+++ b/mpisppy/tests/test_feasible_xhat.py
@@ -1,0 +1,180 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Tests for the ``feasible_xhat_creator`` convention and its
+``average_xhat_nonants`` helper.
+
+Two prototypes are exercised: netdes (LP-relax + ceil, via the helper)
+and sslp (LP-relax + average + round, rolls own). The convention's
+contract is that the returned candidate must be feasible to fix in
+every real scenario's per-scenario subproblem; the netdes test
+verifies this directly.
+"""
+
+import os
+import sys
+import unittest
+
+import numpy as np
+import pyomo.environ as pyo
+from pyomo.opt import TerminationCondition
+
+import mpisppy.utils.sputils as sputils
+from mpisppy.utils.xhat_helpers import average_xhat_nonants
+from mpisppy.tests.utils import get_solver
+
+_EXAMPLES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "examples",
+)
+sys.path.insert(0, os.path.join(_EXAMPLES_DIR, "farmer"))
+sys.path.insert(0, os.path.join(_EXAMPLES_DIR, "netdes"))
+sys.path.insert(0, os.path.join(_EXAMPLES_DIR, "sslp"))
+
+import farmer  # noqa: E402
+import netdes  # noqa: E402
+import netdes_auxiliary  # noqa: E402
+import sslp_auxiliary  # noqa: E402
+
+solver_available, solver_name, _, _ = get_solver()
+
+_NETDES_DATA = os.path.join(
+    _EXAMPLES_DIR, "netdes", "data", "network-10-20-L-01.dat"
+)
+_SSLP_DATA_DIR = os.path.join(
+    _EXAMPLES_DIR, "sslp", "data", "sslp_15_45_5", "scenariodata"
+)
+
+
+class TestAverageXhatNonantsContract(unittest.TestCase):
+    """Solver-free contract checks for the helper."""
+
+    def test_rejects_no_node_list(self):
+        def bad_creator(name):
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var()
+            m.obj = pyo.Objective(expr=m.x)
+            return m
+
+        with self.assertRaises(RuntimeError) as ctx:
+            average_xhat_nonants(bad_creator, solver_name="cplex")
+        self.assertIn("_mpisppy_node_list", str(ctx.exception))
+
+    def test_rejects_multi_stage(self):
+        def two_node_creator(name):
+            m = pyo.ConcreteModel()
+            m.x = pyo.Var()
+            m.y = pyo.Var()
+            m.fsc = pyo.Expression(expr=m.x)
+            m.obj = pyo.Objective(expr=m.x + m.y)
+            sputils.attach_root_node(m, m.fsc, [m.x])
+            # tack on a fake second node
+            from mpisppy.scenario_tree import ScenarioNode
+            m._mpisppy_node_list.append(
+                ScenarioNode("STAGE2", 1.0, 2, m.fsc, [m.y], m,
+                             parent_name="ROOT")
+            )
+            return m
+
+        with self.assertRaises(RuntimeError) as ctx:
+            average_xhat_nonants(two_node_creator, solver_name="cplex")
+        self.assertIn("two-stage only", str(ctx.exception))
+
+
+@unittest.skipIf(not solver_available, "no solver available")
+class TestAverageXhatNonantsOnFarmer(unittest.TestCase):
+    """End-to-end on farmer (whose first stage is continuous)."""
+
+    def test_returns_array_of_correct_length(self):
+        arr = average_xhat_nonants(
+            farmer.average_scenario_creator,
+            solver_name=solver_name,
+            scenario_creator_kwargs={"num_scens": 6},
+        )
+        self.assertIsInstance(arr, np.ndarray)
+        self.assertEqual(arr.shape, (3,))  # DEVOTED_ACRES over 3 crops
+
+    def test_relax_integrality_is_no_op_on_continuous_first_stage(self):
+        a = average_xhat_nonants(
+            farmer.average_scenario_creator,
+            solver_name=solver_name,
+            scenario_creator_kwargs={"num_scens": 6},
+        )
+        b = average_xhat_nonants(
+            farmer.average_scenario_creator,
+            solver_name=solver_name,
+            scenario_creator_kwargs={"num_scens": 6},
+            relax_integrality=True,
+        )
+        np.testing.assert_allclose(a, b, atol=1e-6)
+
+
+@unittest.skipIf(not solver_available, "no solver available")
+class TestNetdesFeasibleXhatCreator(unittest.TestCase):
+    """End-to-end check: netdes_auxiliary.feasible_xhat_creator returns
+    a candidate that is integer-valued and feasible to pin in every
+    real scenario."""
+
+    def setUp(self):
+        from parse import parse
+        full = parse(_NETDES_DATA, scenario_ix=None)
+        self.K = full["K"]
+        self.cache = netdes_auxiliary.feasible_xhat_creator(
+            solver_name=solver_name, path=_NETDES_DATA,
+        )
+
+    def test_returns_root_dict(self):
+        self.assertIn("ROOT", self.cache)
+        self.assertEqual(set(self.cache.keys()), {"ROOT"})
+
+    def test_values_are_integer(self):
+        arr = self.cache["ROOT"]
+        self.assertTrue(np.allclose(arr, np.round(arr), atol=1e-9),
+                        f"ceil output is not integer-valued: {arr}")
+
+    def test_pins_are_feasible_in_every_real_scenario(self):
+        arr = self.cache["ROOT"]
+        for k in range(self.K):
+            sname = f"Scenario{k}"
+            scen = netdes.scenario_creator(sname, path=_NETDES_DATA)
+            root = scen._mpisppy_node_list[0]
+            for v, val in zip(root.nonant_vardata_list, arr):
+                v.fix(val)
+            solver = pyo.SolverFactory(solver_name)
+            if sputils.is_persistent(solver):
+                solver.set_instance(scen)
+                results = solver.solve(tee=False)
+            else:
+                results = solver.solve(scen, tee=False)
+            tc = results.solver.termination_condition
+            self.assertIn(
+                tc, (TerminationCondition.optimal, TerminationCondition.feasible),
+                f"netdes pin infeasible on {sname}: tc={tc}, xhat={arr}",
+            )
+
+
+@unittest.skipIf(not solver_available, "no solver available")
+@unittest.skipIf(not os.path.isdir(_SSLP_DATA_DIR), "sslp data not found")
+class TestSslpFeasibleXhatCreator(unittest.TestCase):
+
+    def test_returns_integer_root_dict(self):
+        cache = sslp_auxiliary.feasible_xhat_creator(
+            solver_name=solver_name,
+            num_scens=5,
+            data_dir=_SSLP_DATA_DIR,
+        )
+        self.assertIn("ROOT", cache)
+        arr = cache["ROOT"]
+        self.assertEqual(arr.shape, (15,))  # 15 servers in sslp_15_45_5
+        self.assertTrue(np.allclose(arr, np.round(arr), atol=1e-9))
+        self.assertTrue(np.all((arr >= 0) & (arr <= 1)),
+                        f"FacilityOpen out of [0,1]: {arr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/xhat_helpers.py
+++ b/mpisppy/utils/xhat_helpers.py
@@ -1,0 +1,140 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Helpers for producing candidate xhat values from a deterministic proxy
+of a stochastic program.
+
+Used by ``feasible_xhat_creator`` implementations in
+``examples/<model>/<model>_auxiliary.py`` and by downstream consumers
+(e.g. findW's pin-dual algorithm) that need a first-stage point feasible
+to fix in every real scenario's per-scenario subproblem.
+
+The Jensen's xhat path inside mpi-sppy tolerates a per-scenario-infeasible
+candidate by silently skipping it; downstream consumers that pin a
+candidate and solve a per-scenario MIP cannot, so they need a stronger
+contract. ``feasible_xhat_creator`` is the entry point for that
+contract; ``average_xhat_nonants`` is the common-case engine that the
+implementations call when they have an ``average_scenario_creator``.
+
+The rounding/repair rule that turns the average-scenario solution into
+a feasible candidate is model-specific (depends on monotonicity of
+recourse feasibility in each first-stage variable) and lives in each
+module's ``feasible_xhat_creator``, not here.
+"""
+
+import numpy as np
+import pyomo.environ as pyo
+from pyomo.opt import TerminationCondition
+
+import mpisppy.utils.sputils as sputils
+
+
+def _solve_and_extract_root(model, solver_name, solver_options):
+    solver = pyo.SolverFactory(solver_name)
+    for k, v in (solver_options or {}).items():
+        solver.options[k] = v
+    if sputils.is_persistent(solver):
+        solver.set_instance(model)
+        results = solver.solve(tee=False)
+    else:
+        results = solver.solve(model, tee=False)
+    tc = results.solver.termination_condition
+    if tc not in (TerminationCondition.optimal, TerminationCondition.feasible):
+        raise RuntimeError(
+            f"solve in xhat_helpers failed with termination_condition={tc}"
+        )
+    root = model._mpisppy_node_list[0]
+    return np.array(
+        [pyo.value(v) for v in root.nonant_vardata_list], dtype="d"
+    )
+
+
+def _check_two_stage(model, who):
+    if not hasattr(model, "_mpisppy_node_list"):
+        raise RuntimeError(
+            f"{who}: scenario must have _mpisppy_node_list attached "
+            "(via sputils.attach_root_node)."
+        )
+    if len(model._mpisppy_node_list) != 1:
+        raise RuntimeError(
+            f"{who} is two-stage only; got "
+            f"{len(model._mpisppy_node_list)} tree nodes."
+        )
+
+
+def average_xhat_nonants(
+    average_scenario_creator,
+    *,
+    solver_name,
+    scenario_creator_kwargs=None,
+    solver_options=None,
+    relax_integrality=False,
+    scenario_name="AverageScenario",
+):
+    """Build, optionally LP-relax, and solve the average scenario; return
+    its ROOT first-stage values as a 1-D ``np.ndarray`` in
+    ``_mpisppy_node_list[0].nonant_vardata_list`` order.
+
+    Two-stage only. Returns the bare array; callers that need the
+    ``Xhat_Eval._fix_nonants`` cache form wrap as ``{"ROOT": arr}``.
+
+    Note: solving the (LP-relaxed) average scenario is **not** the same
+    as the per-scenario LP-xbar. The average-scenario solution can
+    underestimate which first-stage variables need to be active when the
+    candidate must be feasible across every real scenario, because data
+    averaging can mask scenario-specific demand patterns. For a
+    feasibility-oriented candidate, prefer ``lp_xbar_nonants``.
+    """
+    kwargs = scenario_creator_kwargs or {}
+    avg = average_scenario_creator(scenario_name, **kwargs)
+    _check_two_stage(avg, "average_xhat_nonants")
+    if relax_integrality:
+        pyo.TransformationFactory("core.relax_integer_vars").apply_to(avg)
+    return _solve_and_extract_root(avg, solver_name, solver_options)
+
+
+def lp_xbar_nonants(
+    scenario_creator,
+    scenario_names,
+    *,
+    solver_name,
+    scenario_creator_kwargs=None,
+    solver_options=None,
+):
+    """For each scenario, solve its LP relaxation; return the
+    probability-weighted average of ROOT nonants as a 1-D ``np.ndarray``.
+
+    Two-stage only. Each scenario's ``_mpisppy_probability`` is used as
+    its weight; the literal string ``"uniform"`` is interpreted as
+    ``1/len(scenario_names)``. Weights are renormalized at the end so a
+    sub-list of scenarios produces a coherent average.
+
+    This is the per-scenario LP-xbar that downstream consumers
+    (e.g. findW's pin-dual tests) round to obtain a candidate
+    first-stage feasible in every real scenario's per-scenario
+    subproblem. For models where opening more first-stage activity
+    only loosens recourse, ceiling the LP-xbar opens every variable
+    that any scenario's LP wanted positive, which makes the candidate
+    a strict cover.
+    """
+    kwargs = scenario_creator_kwargs or {}
+    arr_sum = None
+    weight_sum = 0.0
+    n = len(scenario_names)
+    for sname in scenario_names:
+        m = scenario_creator(sname, **kwargs)
+        _check_two_stage(m, "lp_xbar_nonants")
+        prob = getattr(m, "_mpisppy_probability", "uniform")
+        if prob == "uniform":
+            prob = 1.0 / n
+        pyo.TransformationFactory("core.relax_integer_vars").apply_to(m)
+        vals = _solve_and_extract_root(m, solver_name, solver_options)
+        contribution = prob * vals
+        arr_sum = contribution if arr_sum is None else arr_sum + contribution
+        weight_sum += prob
+    return arr_sum / weight_sum


### PR DESCRIPTION
## Summary

- Adds a `feasible_xhat_creator(*, solver_name, ..., **kwargs) -> {nodename: np.ndarray}` convention for example modules, returning a candidate first-stage point feasible to fix in *every* real scenario's per-scenario subproblem. Distinct contract from Jensen's xhat (which silently skips infeasibility); needed by downstream consumers like findW's pin-dual algorithm where the pin cannot fall back.
- Adds `mpisppy/utils/xhat_helpers.py` with two engines: `average_xhat_nonants` (one-shot avg-scenario solve) and `lp_xbar_nonants` (per-scenario LP-relax + probability-weighted xbar). The second is what "feasible everywhere" callers actually want, since LP-relaxing the average scenario can underestimate which first-stage variables need to be active across real scenarios.
- Prototypes the convention in `examples/netdes/netdes_auxiliary.py` (lp_xbar + `np.ceil`, leveraging arc-open recourse monotonicity) and `examples/sslp/sslp_auxiliary.py` (lp_xbar + `np.round`, set-covering recourse monotonicity). Auxiliary files keep the intro examples uncluttered; see Pyomo/mpi-sppy#676 for the broader cleanup proposal that would also move `average_scenario_creator` out of `farmer.py`/`netdes.py`.
- Not added to farmer (continuous first stage, no rounding needed).

The rounding rule is intentionally per-module: it depends on per-variable monotonicity of recourse feasibility, which the framework cannot detect from a model.

## Test plan

- [x] `mpisppy/tests/test_feasible_xhat.py` (8 tests, all pass) -- including a per-scenario pin-feasibility check on netdes that exercises the actual contract: build each real scenario, fix nonants to the candidate, solve, expect optimal/feasible.
- [x] `test_jensens.py` regression (33/33 pass) -- the helper refactor doesn't touch the Jensen's mixin.
- [x] Focused serial subset: test_sputils, test_config, test_solver_spec, test_scenario_tree, test_extensions, test_ph_main, test_ef_ph (352 pass; one pre-existing `test_scenario_lpwriter_extension` failure that reproduces on origin/main, unrelated).
- [x] `ruff check .` clean.
- [ ] CI on PR.