### PR TITLE
flex-ranks phase 2: communication layer (unequal-rank fullcomm window + multi-source reader)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -971,6 +971,13 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 2 coverage run $COV_ARGS -m mpi4py test_with_cylinders.py
 
+      - name: run flexible (unequal) rank tests
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          mpiexec -np 6 -oversubscribe coverage run $COV_ARGS -m mpi4py test_spwindow_multisource.py
+          mpiexec -np 6 -oversubscribe coverage run $COV_ARGS -m mpi4py test_flexible_rank_cylinders.py
+
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1127,7 +1127,11 @@ jobs:
             mpisppy/tests/test_reduced_costs_rho_bundles.py \
             mpisppy/tests/test_rho_deprecations.py \
             mpisppy/tests/test_buffer_inspect.py \
-            mpisppy/tests/test_comm_lor_check.py
+            mpisppy/tests/test_comm_lor_check.py \
+            mpisppy/tests/test_rank_apportionment.py \
+            mpisppy/tests/test_overlap_map.py \
+            mpisppy/tests/test_spwindow_partial_get.py \
+            mpisppy/tests/test_flexible_rank_ratios.py
 
       - name: Upload coverage data
         if: always()

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -373,8 +373,10 @@ window creation.  Cons:
   Because total rank counts in the thousands are a real operating
   regime here, the O(N) startup allgather and its O(N)-per-rank layout
   storage must be replaced by the two-level (or local-compute) scheme
-  **before flexible ranks are advertised as production-supported**.
-  That replacement is its own focused change — it touches only how
+  **before flexible ranks is documented or recommended for production
+  use** (it can land on `main` before then, since it is inert until a
+  non-default ratio).  That replacement is its own focused change — it
+  touches only how
   `strata_buffer_layouts` is populated at startup, not the multi-source
   reader — so it is tracked as a release-gate item rather than folded
   into the feature phases, letting it be reviewed and scale-tested on
@@ -770,19 +772,20 @@ are subtle.  If isolation is ever genuinely wanted, prefer a branch in
 the upstream repository over a separate fork -- same isolation, far less
 CI and merge friction.)
 
-**Gate reliance on the feature with an MPI CI matrix.**  There is no
-default to flip, but before the `fullcomm` path is advertised as
-supported, exercise it on at least two MPI implementations (e.g. OpenMPI
-and MPICH) and more than one mpi4py / MPI version, since that path is
-where the RMA-portability risk lives.
+**Prerequisites before the feature is recommended for production use.**
+There is no default to flip, but before the `fullcomm` path is
+documented or recommended for production use, exercise it on at least
+two MPI implementations (e.g. OpenMPI and MPICH) and more than one
+mpi4py / MPI version, since that path is where the RMA-portability risk
+lives.
 
-The same advertisement gate carries the **scalable layout exchange**:
-the interim `fullcomm.allgather` (see the Option D layout-exchange note)
-must be replaced by the two-level or local-compute scheme before the
-feature is advertised as production-supported, because total rank counts
-in the thousands are a real operating regime here.  Tracked as a
-release-gate item so it lands before scale use without gating the
-feature phases on it.
+The same "finish before recommending it" list carries the **scalable
+layout exchange**: the interim `fullcomm.allgather` (see the Option D
+layout-exchange note) must be replaced by the two-level or local-compute
+scheme before the feature is documented or recommended for production
+use, because total rank counts in the thousands are a real operating
+regime here.  Both are prerequisites for recommending the feature, not
+for landing the intervening phases on `main`.
 
 
 ### Possible future optimization (out of scope)

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -363,6 +363,23 @@ window creation.  Cons:
   over one anchor rank per cylinder — rather than a single
   `fullcomm.allgather`, which scales worse at N=thousands.
 
+  *What the communication-layer cut actually ships, and the release
+  gate.*  The first cut uses a single `fullcomm.allgather` for the
+  unequal-rank layout exchange.  This is deliberate but interim: it is
+  effectively zero new code (the existing `SPWindow` exchange run on
+  `fullcomm` instead of `strata_comm`), it is a one-time *startup* cost
+  on a cold path — not the RMA hot path — and at development/test scale
+  (a handful of ranks) it is free.  It is **not** the end state.
+  Because total rank counts in the thousands are a real operating
+  regime here, the O(N) startup allgather and its O(N)-per-rank layout
+  storage must be replaced by the two-level (or local-compute) scheme
+  **before flexible ranks are advertised as production-supported**.
+  That replacement is its own focused change — it touches only how
+  `strata_buffer_layouts` is populated at startup, not the multi-source
+  reader — so it is tracked as a release-gate item rather than folded
+  into the feature phases, letting it be reviewed and scale-tested on
+  its own.  See §Gate reliance on the feature with an MPI CI matrix.
+
   *Lock granularity.*  `MPI_Win_lock(rank=target, ...)` is per-
   target-rank in the MPI spec, not per-window — a writer's exclusive
   lock on its own buffer does not block readers fetching from a
@@ -632,9 +649,12 @@ the first pass bundled into "Phase 0" has already landed separately.
 **Phase 2: Communication layer** (additive; reached only when a ratio
 differs from 1.0)
 
-- Add a `fullcomm`-based or locally-computed layout exchange for the
-  unequal-rank path (Option D's addressing), *alongside* the existing
+- Add the `fullcomm.allgather` layout exchange for the unequal-rank
+  path (Option D's addressing), *alongside* the existing
   `strata_comm`-based exchange, which the equal-rank path keeps using.
+  This is the interim exchange; the scalable replacement is a release
+  gate, not a feature phase (see the Option D layout-exchange note and
+  §Gate reliance on the feature with an MPI CI matrix).
 - Implement multi-source `get_receive_buffer()` using overlap maps, as
   a path taken only under non-default ratios; the single-source reader
   is unchanged for the equal-rank case.
@@ -755,6 +775,14 @@ default to flip, but before the `fullcomm` path is advertised as
 supported, exercise it on at least two MPI implementations (e.g. OpenMPI
 and MPICH) and more than one mpi4py / MPI version, since that path is
 where the RMA-portability risk lives.
+
+The same advertisement gate carries the **scalable layout exchange**:
+the interim `fullcomm.allgather` (see the Option D layout-exchange note)
+must be replaced by the two-level or local-compute scheme before the
+feature is advertised as production-supported, because total rank counts
+in the thousands are a real operating regime here.  Tracked as a
+release-gate item so it lands before scale use without gating the
+feature phases on it.
 
 
 ### Possible future optimization (out of scope)

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -3,6 +3,14 @@
 Status: Design Document (Draft — second pass)
 Date: 2026-05-24
 
+**Key decision up front.**  Flexible ranks are added as a
+*gated-additive* feature, not a rework of the path every run exercises.
+At equal rank ratios (today's only case) the existing `strata_comm`
+windows and single-source reader run unchanged; the new `fullcomm` +
+overlap-map machinery is reached only when a rank ratio differs from
+1.0.  The rationale, trade-offs, and rollout workflow are in
+§Development and rollout strategy.
+
 ### Terminology
 
 - **Window:** An MPI one-sided ("RMA") addressing scope, created
@@ -243,7 +251,9 @@ count to get each cylinder's distribution, then compute pairwise
 overlaps.
 
 For example, with a 4-rank hub and a 2-rank spoke, both handling 10
-scenarios:
+scenarios (the per-rank split below is illustrative — the real split is
+whatever `scen_names_to_ranks` produces — and is chosen so that a hub
+rank straddles the spoke's boundary):
 
 ========  ==================  ==================
           Hub (4 ranks)       Spoke (2 ranks)
@@ -254,23 +264,28 @@ Rank 2    scen4, scen5
 Rank 3    scen6--scen9
 ========  ==================  ==================
 
-Hub rank 0 needs to read from spoke rank 0 (which has scen0--scen4),
-extracting only the portion for scen0--scen1.  Hub rank 2 also reads
-from spoke rank 0, extracting scen4--scen5.
+Hub rank 0 reads from spoke rank 0 (which holds scen0--scen4),
+extracting only the portion for scen0--scen1.  Hub rank 2 holds
+scen4--scen5, which *straddles* the spoke's split: scen4 lives in spoke
+rank 0 (at offset 4) and scen5 in spoke rank 1 (at offset 0), so hub
+rank 2 reads one segment from each.  Hub rank 3's scen6--scen9 sit at
+offsets 1--4 within spoke rank 1's buffer (which starts at scen5).
 
-The overlap map for hub rank 0 reading from the spoke would be:
+Taking one nonant per scenario for simplicity, the overlap map (in
+nonant units) for hub rank 0 reading from the spoke would be:
 ```
 [(spoke_rank=0, remote_offset=0, local_offset=0, count=2)]
 ```
 
-For hub rank 2:
+For hub rank 2 (the straddle — two segments):
 ```
-[(spoke_rank=0, remote_offset=4, local_offset=0, count=2)]
+[(spoke_rank=0, remote_offset=4, local_offset=0, count=1),
+ (spoke_rank=1, remote_offset=0, local_offset=1, count=1)]
 ```
 
 For hub rank 3:
 ```
-[(spoke_rank=1, remote_offset=0, local_offset=0, count=4)]
+[(spoke_rank=1, remote_offset=1, local_offset=0, count=4)]
 ```
 
 These maps are computed once at startup and reused for every
@@ -294,7 +309,10 @@ multi-stage problems (though for two-stage problems they are uniform).
 
 #### Window Topology Options
 
-Spoiler alert: we are going to recommend option D, which is similar to A.
+Of the options below we settle on Option D, though only as the topology
+for the unequal-rank path; it is similar to Option A.  See §Development
+and rollout strategy for why it is added alongside the existing
+`strata_comm` rather than replacing it.
 
 **Option A: Single global window on `fullcomm`**
 
@@ -354,9 +372,30 @@ window creation.  Cons:
   those pairs) is an incremental fix that does not require abandoning
   Option D.
 
-**Recommendation:** Option D.  The window is on `fullcomm` (or a
-subset), and each rank knows which global ranks to read from via the
-overlap maps.
+**Recommendation:** Option D, *as the topology for the unequal-rank
+path only*.  A given run uses exactly one topology, chosen at startup
+from the rank ratios:
+
+- *Equal-rank run* (all ratios 1.0): create `strata_comm` and
+  `cylinder_comm`, and put the window on `strata_comm` -- exactly as
+  today.
+- *Unequal-rank run* (any ratio differs from 1.0): **`strata_comm` is
+  not created at all.**  The strata grouping (`color =
+  global_rank // n_spcomms`, "rank *i* of every cylinder") is undefined
+  when cylinders have different rank counts -- that is the whole reason
+  for Option D.  Create `cylinder_comm` only (each cylinder is a
+  contiguous block of apportioned ranks, so the intra-cylinder grouping
+  is still well-defined), put the window on `fullcomm`, and have each
+  rank address peers by global rank via the overlap maps.  Each rank
+  takes its cylinder index from the apportionment rather than from
+  `strata_rank`.
+
+So `strata_comm` is *retained in the codebase* -- the equal-rank path
+still uses it unchanged -- but it is *not created in an unequal-rank
+run*.  This is additive, not a replacement: the textbook "abandon
+`strata_comm`" framing in the Option D description above would remove it
+for *all* runs, which this design does not do.  See §Development and
+rollout strategy.
 
 
 #### Multi-Source Read Assembly
@@ -491,14 +530,28 @@ unnecessary given the per-field analysis).
 
 #### `spin_the_wheel.py`
 
-- Remove the `n_proc % n_spcomms == 0` check.
-- Replace the uniform `MPI_Comm_split` with the apportionment
-  algorithm (§User Interface) that respects per-cylinder rank counts.
+- Keep the `n_proc % n_spcomms == 0` check on the equal-rank path; the
+  unequal-rank path bypasses it, since apportionment (§User Interface)
+  removes the requirement that `n_proc` divide evenly by cylinder count.
+- On the unequal-rank path, replace the uniform `MPI_Comm_split` with
+  the apportionment algorithm (§User Interface) that respects
+  per-cylinder rank counts.  The equal-rank path keeps the uniform
+  split unchanged.
 - `cylinder_comm` creation still uses `MPI_Comm_split` (all ranks in
   the same cylinder get the same color).
-- `strata_comm` is removed (Option D); the window moves to `fullcomm`.
-- Indexing that assumes a fixed `strata_rank` meaning must change;
-  each rank needs to know its cylinder index directly.
+- `strata_comm` is **retained in the codebase** for the equal-rank
+  path: when ranks are equal across cylinders, `strata_comm` and its
+  per-strata windows are created and used exactly as today.  In an
+  unequal-rank run `strata_comm` is **not created** -- the strata
+  grouping is undefined for cylinders of different sizes -- and the
+  window is built on `fullcomm` instead (Option D's addressing).  The
+  choice is made once at startup; a run creates one or the other, never
+  both.  `cylinder_comm` is created in both cases.  See §Development and
+  rollout strategy.
+- In the unequal-rank path, indexing that assumes a fixed `strata_rank`
+  meaning does not apply; each rank addresses peers by global rank via
+  the overlap maps, taking its cylinder index from the apportionment.
+  The equal-rank path's `strata_rank` indexing is unchanged.
 
 #### `spbase.py`
 
@@ -507,25 +560,30 @@ unnecessary given the per-field analysis).
 
 #### `spwindow.py`
 
-- `SPWindow.get()` must support partial reads (offset + count).
-- The buffer layout exchange must use a communicator that spans all
-  cylinders (not `strata_comm`), or be computed locally from the
-  static rank-count/scenario-map data (preferred).
-- Buffer validation must account for asymmetric sizes: a receiver's
-  expected size may differ from the sender's, and that is fine as long
-  as each requested segment fits within the sender's buffer.
+- `SPWindow.get()` must support partial reads (offset + count) -- an
+  additive capability the equal-rank path does not exercise.
+- For the unequal-rank path, the buffer layout must be exchanged over a
+  communicator that spans all cylinders, or (preferred) computed
+  locally from the static rank-count/scenario-map data.  The
+  equal-rank path keeps its existing `strata_comm` allgather.
+- Buffer validation must account for asymmetric sizes on the
+  multi-source path: a receiver's expected size may differ from the
+  sender's, and that is fine as long as each requested segment fits
+  within the sender's buffer.
 - No field-length or layout changes: every field keeps its current
   per-scenario / global / scalar sizing.  (Canonicalization is *not*
   part of this design.)
 
 #### `spcommunicator.py`
 
-- `register_receive_fields()` builds overlap maps instead of assuming
-  1-to-1 rank correspondence.
-- `get_receive_buffer()` supports multi-source assembly, with the
-  per-field coherence policy applied.
+- `register_receive_fields()` builds overlap maps for the unequal-rank
+  path; the equal-rank path retains the 1-to-1 rank correspondence.
+- `get_receive_buffer()` gains a multi-source assembly path (with the
+  per-field coherence policy applied), selected when ratios differ; the
+  single-source path is unchanged at equal ranks.
 - `put_send_buffer()` is unchanged (each rank writes its own data).
-- `_validate_recv_field()` is relaxed to per-segment validation.
+- `_validate_recv_field()` gains per-segment validation for the
+  multi-source path; equal-rank validation is unchanged.
 - The `synchronize` parameter's `cylinder_comm.Barrier()` / `Allreduce`
   still work within a cylinder.
 
@@ -571,12 +629,17 @@ the first pass bundled into "Phase 0" has already landed separately.
   various rank-count combinations (including the equal-rank identity
   case).
 
-**Phase 2: Communication layer**
+**Phase 2: Communication layer** (additive; reached only when a ratio
+differs from 1.0)
 
-- Replace the `strata_comm`-based layout exchange with a
-  `fullcomm`-based or locally-computed layout (Option D).
-- Implement multi-source `get_receive_buffer()` using overlap maps.
-- Relax `_validate_recv_field()` to per-segment validation.
+- Add a `fullcomm`-based or locally-computed layout exchange for the
+  unequal-rank path (Option D's addressing), *alongside* the existing
+  `strata_comm`-based exchange, which the equal-rank path keeps using.
+- Implement multi-source `get_receive_buffer()` using overlap maps, as
+  a path taken only under non-default ratios; the single-source reader
+  is unchanged for the equal-rank case.
+- Add per-segment validation for the multi-source path; leave
+  `_validate_recv_field()` as-is on the equal-rank path.
 - Test the relaxed-coherence per-scenario fields first (`NONANTS_VALS`)
   with a simple case: hub with 4 ranks, Lagrangian spoke with 2 ranks.
 
@@ -609,6 +672,91 @@ the first pass bundled into "Phase 0" has already landed separately.
   they should compose with async senders; verify and add tests.
 
 
+### Development and rollout strategy
+
+These changes touch a low-level, implementation-sensitive corner of the
+stack -- MPI one-sided (RMA) communication through mpi4py -- where
+behavior varies across MPI implementations (OpenMPI, MPICH, vendor
+builds) and versions, and where passive-target RMA (`Lock` / `Get` /
+`Put`) is the flakiest part of the spec.  Reviews of this material are
+necessarily slow, and a regression in the communicator layer would
+affect *every* run, not just flexible-rank runs.  The guiding principle
+is therefore to **keep the equal-rank path off the table entirely**: the
+common case that every current user exercises must execute the same code
+after this feature lands as before it.
+
+**Gated-additive, not a live-path rework.**  An earlier draft proposed
+replacing `strata_comm` with a single `fullcomm` window (Option D) for
+*all* runs, introduced via branch-by-abstraction behind a runtime flag
+that defaulted to the old path and was to be removed once the new path
+proved out.  We reject that here.  A replacement -- even one staged
+behind a flag -- rewrites the path every run hits, and the temporary
+"two implementations behind a flag, delete the old one later" state is
+exactly the kind of clutter that becomes permanent: removing the proven
+path is always scarier than keeping it, the two paths drift because tests
+rarely exercise both equally, and the toggle outlives its purpose.
+
+Instead, the new `fullcomm` + overlap-map machinery is **purely
+additive and gated by the feature itself**.  The rank-ratio
+configuration *is* the gate -- no separate runtime flag:
+
+- When all ratios are 1.0 (today's only possibility), the system builds
+  the existing per-`strata_comm` windows and uses the existing
+  single-source reader, unchanged.  Current users execute the same bytes
+  they execute now.
+- When any ratio differs from 1.0, `make_windows()` builds the
+  `fullcomm` window (Option D's topology) and the multi-source,
+  overlap-map reader is used.  A run uses exactly one topology
+  throughout, chosen once at startup; the two never coexist within a
+  single run.
+
+This makes *every* phase inert with respect to the equal-rank path --
+there is no live-path phase to sequence around.  Each phase adds gated
+code that is unreachable until a user opts in with a non-default ratio,
+so each can land on `main` incrementally and safely.
+
+**The production fallback comes for free.**  The branch-by-abstraction
+flag was justified as a runtime escape hatch for clusters with buggy
+RMA.  Gated-additive preserves that property without a second
+implementation of the equal-rank path: if the `fullcomm` path
+misbehaves on some MPI build, the user sets the ratios back to 1.0 and is
+on the proven path.  Disabling the feature *is* the escape hatch.
+
+**Cost we accept.**  Two window topologies live in the tree
+permanently -- per-`strata_comm` windows for the equal-rank case and the
+`fullcomm` window for the unequal case -- and we do *not* plan a later
+unification onto a single communicator.  This is benign clutter: the two
+are not competing implementations of the same behavior (which would
+drift), but the right tool for two different cases, partitioned by a
+condition decided once at startup.  The thing given up is the aesthetic
+of a single communicator; if a future benchmark ever shows `fullcomm` is
+strictly better even at equal ranks, the cutover remains available as
+separate work, but it is not undertaken speculatively for an unstable
+dependency we do not control.
+
+**Workflow: stacked PRs.**  Because reviews of this material are slow,
+phases are developed as a *stack* of pull requests rather than waiting
+for each to merge before the next begins.  Each phase lives on its own
+short-lived branch whose PR targets the branch *below* it (phase N+1 onto
+phase N, phase 1 onto `main`); the stack is reviewed and merged
+bottom-up, each PR being retargeted to `main` as the one beneath it
+lands.  This keeps work moving while earlier PRs sit in review, yet --
+unlike a long-lived feature branch or a development fork -- every change
+stays small, individually reviewable, and revertible/bisectable, and
+`main` stays continuously shippable.  (A big-bang integration merge of an
+entire multi-phase feature is the opposite: a large, hard-to-review,
+hard-to-bisect surface, which is *more* dangerous for code whose failures
+are subtle.  If isolation is ever genuinely wanted, prefer a branch in
+the upstream repository over a separate fork -- same isolation, far less
+CI and merge friction.)
+
+**Gate reliance on the feature with an MPI CI matrix.**  There is no
+default to flip, but before the `fullcomm` path is advertised as
+supported, exercise it on at least two MPI implementations (e.g. OpenMPI
+and MPICH) and more than one mpi4py / MPI version, since that path is
+where the RMA-portability risk lives.
+
+
 ### Possible future optimization (out of scope)
 
 The first-stage portion of `BEST_XHAT` / `RECENT_XHATS` is genuinely
@@ -623,15 +771,18 @@ work.
 
 ### Backward Compatibility
 
-When all rank ratios are 1.0 (the default), the system must behave
-identically to the current implementation.  The overlap maps degenerate
-to single-segment identity mappings, multi-source reads become
-single-source reads, and the strict/relaxed coherence checks are
-satisfied trivially (one source per field).  Because this design makes
-**no field-layout changes**, the on-the-wire format is unchanged at
-equal ranks — there is no analogue of the first pass's "Phase 0 changes
-the wire format even at equal ranks" caveat.  Verify by running the
-full existing test suite with the new code and default ratios.
+When all rank ratios are 1.0 (the default), the system behaves
+identically to the current implementation — not via a degenerate case of
+the new machinery, but because the new machinery is **not reached at
+all**.  At equal ratios the existing per-`strata_comm` windows,
+single-source reader, and `strata_rank` addressing run verbatim; the
+overlap maps, `fullcomm` window, and multi-source reader are gated behind
+a non-default ratio (see §Development and rollout strategy).  Because
+this design also makes **no field-layout changes**, the on-the-wire
+format is unchanged at equal ranks — there is no analogue of the first
+pass's "Phase 0 changes the wire format even at equal ranks" caveat.
+Verify by running the full existing test suite with the new code and
+default ratios.
 
 
 ---

--- a/mpisppy/cylinders/overlap_map.py
+++ b/mpisppy/cylinders/overlap_map.py
@@ -1,0 +1,93 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Overlap maps for reading a local-sized field across cylinders that have
+different MPI rank counts.
+
+When two cylinders hold the same scenarios but split them over a different
+number of ranks, a reader rank's local buffer for a per-scenario field is
+backed by one or more *segments* living in remote ranks' buffers.  An
+``OverlapSegment`` records, for one such segment, which remote rank holds
+it and the matching offsets/length (in field *items*, e.g. nonants) in the
+remote and local buffers.
+
+This module is deliberately free of MPI and Pyomo: it consumes the
+contiguous per-rank scenario partition (the ``slices`` produced by
+``_ScenTree.scen_names_to_ranks``) plus a per-scenario item count, so it
+can be unit tested directly.  See
+``doc/designs/flexible_rank_assignments.md`` (the "Overlap Maps" section).
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class OverlapSegment:
+    """One contiguous run of a local field buffer sourced from a single
+    remote rank's buffer.  All offsets/lengths are in field items."""
+    remote_rank: int     # rank in the peer cylinder to read from
+    remote_offset: int   # item offset of this run within the remote buffer
+    local_offset: int    # item offset of this run within the local buffer
+    count: int           # number of items in this run
+
+
+def compute_overlap_segments(local_scen_idxs, remote_slices, items_per_scen):
+    """Segments mapping a local rank's field buffer onto remote buffers.
+
+    Args:
+        local_scen_idxs: ordered global scenario indices held by this
+            (local) rank -- i.e. ``local_slices[local_rank]``.
+        remote_slices: the peer cylinder's partition, ``rank -> ordered
+            list of global scenario indices`` (the ``slices`` output of
+            ``scen_names_to_ranks`` for that cylinder).  Determines both
+            which remote rank holds each scenario and the scenario's
+            offset within that rank's buffer.
+        items_per_scen: sequence indexed by global scenario index giving
+            the number of field items each scenario contributes (e.g.
+            ``len(nonant_indices)``).  Uniform two-stage problems pass a
+            constant for every scenario; multistage problems may vary.
+
+    Returns:
+        list[OverlapSegment]: segments covering the local buffer in order,
+        with contiguous same-rank runs coalesced.  When both cylinders
+        have the same rank count this degenerates to a single identity
+        segment ``(remote_rank=local_rank, remote_offset=0,
+        local_offset=0, count=<all items>)``.
+    """
+    # Invert remote_slices: global scenario index -> (remote rank, item
+    # offset of that scenario within the remote rank's buffer).
+    remote_rank_of_scen = {}
+    remote_offset_of_scen = {}
+    for rank, scen_idxs in enumerate(remote_slices):
+        offset = 0
+        for scen in scen_idxs:
+            remote_rank_of_scen[scen] = rank
+            remote_offset_of_scen[scen] = offset
+            offset += items_per_scen[scen]
+
+    segments = []
+    cur = None
+    local_offset = 0
+    for scen in local_scen_idxs:
+        rank = remote_rank_of_scen[scen]
+        r_off = remote_offset_of_scen[scen]
+        n = items_per_scen[scen]
+        # Coalesce only while we stay on the same remote rank AND the
+        # remote items remain contiguous with the run so far.
+        if cur is not None and cur.remote_rank == rank \
+                and cur.remote_offset + cur.count == r_off:
+            cur.count += n
+        else:
+            if cur is not None:
+                segments.append(cur)
+            cur = OverlapSegment(remote_rank=rank, remote_offset=r_off,
+                                 local_offset=local_offset, count=n)
+        local_offset += n
+    if cur is not None:
+        segments.append(cur)
+    return segments

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -27,8 +27,30 @@ from math import inf
 
 from mpisppy import MPI, global_toc
 from mpisppy.cylinders.spwindow import Field, FieldLengths, SPWindow, padded_len_n_doubles
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+from mpisppy.utils.rank_apportionment import (
+    apportion_ranks,
+    cylinder_bases,
+    rank_to_cylinder,
+)
 
 logger = logging.getLogger(__name__)
+
+# Fields whose buffer length is the same on every rank (global-sized) or a
+# fixed-size record (scalar): Categories 3 and 4 in the design doc. Under
+# unequal rank counts these are read single-source from the publishing
+# cylinder's base rank -- there is nothing to assemble. Every other field is
+# local-sized / per-scenario (Categories 1 and 2) and is read via the
+# overlap-map multi-source path.
+_GLOBAL_OR_SCALAR_FIELDS = frozenset((
+    Field.SHUTDOWN,
+    Field.OBJECTIVE_INNER_BOUND,
+    Field.OBJECTIVE_OUTER_BOUND,
+    Field.BEST_OBJECTIVE_BOUNDS,
+    Field.NONANT_LOWER_BOUNDS,
+    Field.NONANT_UPPER_BOUNDS,
+    Field.EXPECTED_REDUCED_COST,
+))
 
 def communicator_array(data_length: int):
     """
@@ -222,11 +244,30 @@ class SPCommunicator:
         self.strata_comm = strata_comm
         self.cylinder_comm = cylinder_comm
         self.communicators = communicators
-        assert len(communicators) == strata_comm.Get_size()
         self.global_rank = fullcomm.Get_rank()
-        self.strata_rank = strata_comm.Get_rank()
         self.cylinder_rank = cylinder_comm.Get_rank()
-        self.n_spokes = strata_comm.Get_size() - 1
+
+        # Flexible rank assignments (Option D in the design doc): when
+        # strata_comm is None the cylinders have unequal rank counts, so the
+        # strata grouping is undefined and the window lives on fullcomm with
+        # peers addressed by global rank via overlap maps. The cylinder index
+        # plays the role strata_rank does on the equal path -- it indexes
+        # `communicators` and marks the hub as 0 -- so we set strata_rank to it
+        # for the code paths shared with the equal-rank case.
+        self._flex_ranks = strata_comm is None
+        if self._flex_ranks:
+            rank_ratios = [d.get("rank_ratio", 1.0) for d in communicators]
+            self.rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
+            self._cylinder_bases = cylinder_bases(self.rank_counts)
+            self.cylinder_index, _ = rank_to_cylinder(self.global_rank, self.rank_counts)
+            self.strata_rank = self.cylinder_index
+            self.n_spokes = len(communicators) - 1
+        else:
+            assert len(communicators) == strata_comm.Get_size()
+            self.strata_rank = strata_comm.Get_rank()
+            self.cylinder_index = self.strata_rank
+            self.n_spokes = strata_comm.Get_size() - 1
+
         self.opt = spbase_object
         self.inst_time = time.time() # For diagnostics
         if options is None:
@@ -239,6 +280,11 @@ class SPCommunicator:
         self.send_buffers = {}
         # key: Field, value: list of (strata_rank, SPComm, buffer) with that Field
         self.receive_field_spcomms = {}
+
+        # Overlap-map state for the unequal-rank path; empty on the equal path.
+        # Keyed by (field, peer_cylinder_index).
+        self.overlap_maps = {}            # -> list[OverlapSegment] (global ranks)
+        self._overlap_source_ranks = {}   # -> sorted distinct source global ranks
 
         # setup FieldLengths which calculates
         # the length of each buffer type based
@@ -290,6 +336,25 @@ class SPCommunicator:
         self.fields_to_ranks = {}
         self.ranks_to_fields = {}
 
+        if self._flex_ranks:
+            # On the unequal-rank path the window spans fullcomm, so
+            # strata_buffer_layouts is indexed by global rank. Map fields to
+            # peer *cylinder* indices instead (so downstream `origin` values
+            # stay cylinder indices, as on the equal path): every rank in a
+            # cylinder registers the same send fields, so the base rank's
+            # layout names exactly the fields that cylinder publishes.
+            for peer in range(len(self.rank_counts)):
+                if peer == self.cylinder_index:
+                    continue
+                base_layout = self.window.strata_buffer_layouts[self._cylinder_bases[peer]]
+                self.ranks_to_fields[peer] = []
+                for field in base_layout.keys():
+                    if field == Field.WHOLE:
+                        continue
+                    self.fields_to_ranks.setdefault(field, []).append(peer)
+                    self.ranks_to_fields[peer].append(field)
+            return
+
         for rank, buffer_layout in enumerate(self.window.strata_buffer_layouts):
             if rank == self.strata_rank:
                 continue
@@ -337,7 +402,13 @@ class SPCommunicator:
             assert expected_logical_len == my_fa.logical_len()
             assert expected_padded_len == my_fa.padded_len()
         else:
-            self._validate_recv_field(field, origin, length)
+            # On the equal-rank path the remote buffer for `origin` has the
+            # same local sizing as ours, so we can validate it directly. On the
+            # unequal-rank path `origin` is a peer cylinder spanning several
+            # global ranks of differing sizes, so validation is per-segment
+            # (in _build_overlap_map) instead.
+            if not self._flex_ranks:
+                self._validate_recv_field(field, origin, length)
             my_fa = RecvArray(length)
             self.receive_buffers[key] = my_fa
         ## End if
@@ -393,7 +464,11 @@ class SPCommunicator:
         self.register_send_fields()
 
         window_spec = self._build_window_spec()
-        self.window = SPWindow(window_spec, self.strata_comm)
+        # Equal-rank: window on strata_comm (rank i of every cylinder),
+        # addressed by strata_rank. Unequal-rank: window on fullcomm,
+        # addressed by global rank via overlap maps (strata_comm is None).
+        window_comm = self.fullcomm if self._flex_ranks else self.strata_comm
+        self.window = SPWindow(window_spec, window_comm)
 
         self._create_field_rank_mappings()
         self.register_receive_fields()
@@ -410,6 +485,8 @@ class SPCommunicator:
         self.receive_buffers = {}
         self.send_buffers = {}
         self.receive_field_spcomms = {}
+        self.overlap_maps = {}
+        self._overlap_source_ranks = {}
 
         self.window.free()
 
@@ -424,6 +501,10 @@ class SPCommunicator:
 
     def register_receive_fields(self) -> None:
         # print(f"{self.__class__.__name__}: {self.receive_fields=}")
+        if self._flex_ranks:
+            # local global scenario indices held by this rank (its slice in
+            # its own cylinder's partition); used to build overlap maps
+            self._local_scen_idxs = list(self.opt._rank_slices[self.cylinder_rank])
         for field in self.receive_fields:
             # NOTE: If this list is empty after this method, it is up
             #       to the caller to raise an error. Sometimes optional
@@ -437,6 +518,12 @@ class SPCommunicator:
                 if field != Field.WHOLE and field in self.ranks_to_fields[strata_rank]:
                     buff = self.register_recv_field(field, strata_rank)
                     self.receive_field_spcomms[field].append((strata_rank, cls, buff))
+                    # On the unequal-rank path, a per-scenario (local-sized)
+                    # field is assembled from several remote buffers; precompute
+                    # its overlap map now. Global/scalar fields are read
+                    # single-source and need no map.
+                    if self._flex_ranks and field not in _GLOBAL_OR_SCALAR_FIELDS:
+                        self._build_overlap_map(field, strata_rank)
 
     def put_send_buffer(self, buf: SendArray, field: Field):
         """ Put the specified values into the specified locally-owned buffer
@@ -471,6 +558,15 @@ class SPCommunicator:
             is_new (bool): Indicates whether the "gotten" values are new,
                 based on the write_id.
         """
+        if self._flex_ranks:
+            # Unequal-rank path: `origin` is a peer cylinder index. A
+            # per-scenario field is assembled from several of that cylinder's
+            # global ranks via its overlap map; a global/scalar field is read
+            # single-source from the cylinder's base rank.
+            if (field, origin) in self.overlap_maps:
+                return self._flex_get_multi_source(buf, field, origin, synchronize)
+            return self._flex_get_single_source(buf, field, origin, synchronize)
+
         if synchronize:
             self.cylinder_comm.Barrier()
 
@@ -497,6 +593,163 @@ class SPCommunicator:
         else:
             buf._is_new = False
             return False
+
+    # ------------------------------------------------------------------
+    # Unequal-rank (Option D) helpers. These are reached only when
+    # self._flex_ranks is True; the equal-rank path above never calls them.
+    # ------------------------------------------------------------------
+
+    def _items_per_scen_for_field(self, field: Field):
+        """Number of field items each scenario contributes, indexed by global
+        scenario index, for a per-scenario field (used to build overlap maps).
+
+        For the nonant-valued fields this is the per-scenario nonant count,
+        which is uniform across scenarios in a two-stage problem
+        (``opt.nonant_length``). Other per-scenario fields (e.g. the xhat
+        circular buffers) have layouts whose multi-source assembly is deferred
+        to later phases; building an overlap map for them raises here rather
+        than silently mis-assembling.
+        """
+        if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
+            k = self.opt.nonant_length
+            return [k] * len(self.opt.all_scenario_names)
+        raise NotImplementedError(
+            f"multi-source assembly of {field} under unequal rank counts is "
+            f"not implemented in the communication-layer cut; only the "
+            f"per-scenario nonant fields (NONANTS_VALS, RELAXED_NONANTS_VALS, "
+            f"DUALS) are supported so far."
+        )
+
+    def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:
+        """Check that one overlap segment fits within the remote buffer it
+        will be read from (the per-segment analogue of _validate_recv_field)."""
+        layout = self.window.strata_buffer_layouts[remote_global_rank]
+        if field not in layout:
+            raise RuntimeError(
+                f"{self.__class__.__name__} on cylinder {self.cylinder_index} "
+                f"expected {field} on global rank {remote_global_rank} but it "
+                f"is not published there."
+            )
+        _, logical_len, _ = layout[field]
+        remote_data_len = logical_len - 1  # exclude the trailing write_id slot
+        if seg.remote_offset + seg.count > remote_data_len:
+            raise RuntimeError(
+                f"{self.__class__.__name__}: overlap segment for {field} reads "
+                f"items [{seg.remote_offset}, {seg.remote_offset + seg.count}) "
+                f"from global rank {remote_global_rank} whose {field} data "
+                f"length is only {remote_data_len}."
+            )
+
+    def _build_overlap_map(self, field: Field, peer_cylinder: int) -> None:
+        """Precompute, for a per-scenario field and a peer cylinder, the list
+        of remote segments (in global-rank terms) that assemble this rank's
+        local buffer, validating each against the remote layout."""
+        base = self._cylinder_bases[peer_cylinder]
+        rc_peer = self.rank_counts[peer_cylinder]
+        # peer cylinder's scenario partition for its own rank count
+        _, peer_slices, _ = self.opt._scenario_tree.scen_names_to_ranks(rc_peer)
+        items_per_scen = self._items_per_scen_for_field(field)
+        segments = compute_overlap_segments(
+            self._local_scen_idxs, peer_slices, items_per_scen
+        )
+        for seg in segments:
+            seg.remote_rank = base + seg.remote_rank  # peer-local -> global
+            self._validate_segment(field, seg.remote_rank, seg)
+        self.overlap_maps[(field, peer_cylinder)] = segments
+        self._overlap_source_ranks[(field, peer_cylinder)] = \
+            sorted({seg.remote_rank for seg in segments})
+
+    def _flex_get_single_source(self, buf, field, peer_cylinder, synchronize):
+        """Read a global/scalar field single-source from a peer cylinder's base
+        rank. Every rank of the cylinder holds the identical value, so reading
+        the base rank is sufficient and keeps the cross-cylinder write_id
+        agreement check (every local rank reads the same remote rank)."""
+        window_rank = self._cylinder_bases[peer_cylinder]
+        if synchronize:
+            self.cylinder_comm.Barrier()
+        last_id = buf.id()
+        self.window.get(buf.window_array(), window_rank, field)
+        new_id = int(buf.array()[-1])
+        if synchronize:
+            local_val = np.array((new_id,), 'i')
+            sum_ids = np.zeros(1, 'i')
+            self.cylinder_comm.Allreduce((local_val, MPI.INT),
+                                         (sum_ids, MPI.INT),
+                                         op=MPI.SUM)
+            if new_id * self.cylinder_comm.size != sum_ids[0]:
+                buf._is_new = False
+                return False
+        if new_id > last_id:
+            buf._is_new = True
+            buf._pull_id()
+            return True
+        buf._is_new = False
+        return False
+
+    def _flex_get_multi_source(self, buf, field, peer_cylinder, synchronize):
+        """Assemble a per-scenario field from several of a peer cylinder's
+        global ranks using the precomputed overlap map.
+
+        Coherence note. Consumers that read a per-scenario field across a
+        cylinder (e.g. xhatshufflelooper_bounder) require every reader rank to
+        agree on whether the data is "new", because the collectives they run on
+        the new data (Eobjective Allreduce, ROOT bcast, ...) must be entered in
+        lockstep on cylinder_comm. So this mirrors the equal-rank reader's
+        cross-rank write_id agreement rather than accepting each source
+        independently: this rank's id is the coherent floor over its sources
+        (a synchronous hub writes all its ranks at one id, so every reader
+        computes the same value and they proceed together); a transient
+        mixed-id read fails the agreement check and is retried, never accepted
+        out of lockstep. (Per-source relaxed acceptance, which would need
+        consumer cooperation, and strict per-field policies such as DUALS are
+        later phases.)
+        """
+        if synchronize:
+            self.cylinder_comm.Barrier()
+        last_id = buf.id()
+
+        # Read each source's whole field once -- data and trailing write_id
+        # from a single atomic snapshot, exactly as the equal-rank reader does.
+        # Reading the data segment and the id in separate Gets would race the
+        # writer: the hub could Put a source between the two reads, yielding
+        # pre-write NaN data paired with a fresh id, which the gate below would
+        # then accept. One whole-field Get per source closes that window. We
+        # also defer writing into buf until the read is accepted, so a rejected
+        # (mixed-id) read never leaves stale data behind.
+        source_snapshots = {}
+        new_id = None
+        for r in self._overlap_source_ranks[(field, peer_cylinder)]:
+            _, logical_len, padded_len = self.window.strata_buffer_layouts[r][field]
+            snapshot = np.empty(padded_len, dtype="d")
+            self.window.get(snapshot, r, field)
+            source_snapshots[r] = snapshot
+            rid = int(snapshot[logical_len - 1])
+            new_id = rid if new_id is None else min(new_id, rid)
+        if new_id is None:
+            new_id = 0
+
+        if synchronize:
+            local_val = np.array((new_id,), 'i')
+            sum_ids = np.zeros(1, 'i')
+            self.cylinder_comm.Allreduce((local_val, MPI.INT),
+                                         (sum_ids, MPI.INT),
+                                         op=MPI.SUM)
+            if new_id * self.cylinder_comm.size != sum_ids[0]:
+                buf._is_new = False
+                return False
+
+        if new_id > last_id:
+            data_view = buf.value_array()
+            for seg in self.overlap_maps[(field, peer_cylinder)]:
+                snapshot = source_snapshots[seg.remote_rank]
+                data_view[seg.local_offset : seg.local_offset + seg.count] = \
+                    snapshot[seg.remote_offset : seg.remote_offset + seg.count]
+            buf._is_new = True
+            buf._id = new_id
+            buf._array[-1] = new_id
+            return True
+        buf._is_new = False
+        return False
 
     def receive_nonant_bounds(self):
         """ receive the bounds on the nonanticipative variables based on

--- a/mpisppy/cylinders/spwindow.py
+++ b/mpisppy/cylinders/spwindow.py
@@ -178,18 +178,38 @@ class SPWindow:
         return
 
     #### Functions ####
-    def get(self, dest: nptyping.ArrayLike, strata_rank: int, field: Field):
+    def get(self, dest: nptyping.ArrayLike, strata_rank: int, field: Field,
+            item_offset: int = 0, item_count: int = None):
+        """Read a remote rank's buffer for ``field`` into ``dest``.
+
+        By default the whole padded field is transferred (``dest`` must be
+        ``padded_len`` long), preserving the original behavior.  When
+        ``item_count`` is given, only that many doubles are read, starting
+        ``item_offset`` doubles into the field -- a partial read used for
+        multi-source assembly across cylinders with different rank counts
+        (see ``overlap_map.py``).  ``dest`` must then be ``item_count`` long.
+        """
         assert (0 <= strata_rank < len(self.strata_buffer_layouts))
 
         that_layout = self.strata_buffer_layouts[strata_rank]
         assert field in that_layout
 
         (offset, logical_len, padded_len) = that_layout[field]
-        assert np.size(dest) == padded_len
+
+        if item_count is None:
+            count = padded_len
+            disp = offset
+        else:
+            assert item_offset >= 0 and item_count >= 0
+            assert item_offset + item_count <= padded_len, \
+                f"{field=} partial get {item_offset=}+{item_count=} exceeds {padded_len=}"
+            count = item_count
+            disp = offset + item_offset
+        assert np.size(dest) == count
 
         window = self.window
         window.Lock(strata_rank, MPI.LOCK_SHARED)
-        window.Get((dest, padded_len, MPI.DOUBLE), strata_rank, offset)
+        window.Get((dest, count, MPI.DOUBLE), strata_rank, disp)
         window.Unlock(strata_rank)
         return
 

--- a/mpisppy/spin_the_wheel.py
+++ b/mpisppy/spin_the_wheel.py
@@ -12,7 +12,7 @@ from mpisppy import haveMPI, global_toc, MPI
 
 from mpisppy.utils import nice_join
 from mpisppy.utils.sputils import first_stage_nonant_writer, scenario_tree_solution_writer
-from mpisppy.utils.rank_apportionment import apportion_ranks
+from mpisppy.utils.rank_apportionment import apportion_ranks, rank_to_cylinder
 
 class WheelSpinner:
 
@@ -104,31 +104,40 @@ class WheelSpinner:
 
         # Create the necessary communicators
         fullcomm = comm_world
+        global_rank = fullcomm.Get_rank()
 
         # Flexible rank assignments: each cylinder may request a rank ratio
-        # relative to the hub (default 1.0) via a "rank_ratio" dict key. The
-        # uniform case (all ratios 1.0) is handled exactly as before. A
-        # non-uniform request is apportioned (largest-remainder, floor of one)
-        # and reported, but building the communicators for unequal per-cylinder
-        # counts is not yet wired into the communicator/window layer.
+        # relative to the hub (default 1.0) via a "rank_ratio" dict key.
+        #
+        # Equal-rank path (all ratios 1.0, today's only case): build
+        # strata_comm and cylinder_comm with the uniform split, exactly as
+        # before.
+        #
+        # Unequal-rank path (any ratio != 1.0): apportion the rank pool into
+        # contiguous global-rank blocks, one per cylinder (largest-remainder,
+        # floor of one). The strata grouping ("rank i of every cylinder") is
+        # undefined when cylinders differ in size, so strata_comm is NOT
+        # created; strata_comm is passed as None and the communicator layer
+        # puts its window on fullcomm and addresses peers by global rank via
+        # overlap maps (Option D in doc/designs/flexible_rank_assignments.md).
+        # The cylinder index plays strata_rank's role (it selects the
+        # spcomm dict and marks the hub as 0).
         rank_ratios = [d.get("rank_ratio", 1.0) for d in communicator_list]
         if any(r != 1.0 for r in rank_ratios):
             rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
             global_toc(
-                f"Requested per-cylinder rank ratios {rank_ratios} -> "
-                f"rank counts {rank_counts}",
-                fullcomm.Get_rank() == 0,
+                f"Flexible rank assignment: ratios {rank_ratios} -> "
+                f"per-cylinder rank counts {rank_counts}",
+                global_rank == 0,
             )
-            raise NotImplementedError(
-                "Per-cylinder rank counts (flexible rank assignments) are not "
-                f"yet wired into the communicator layer; computed allocation "
-                f"{rank_counts}. Run with all rank_ratio == 1.0 for now."
-            )
-
-        strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
-        strata_rank = strata_comm.Get_rank()
-        cylinder_rank = cylinder_comm.Get_rank()
-        global_rank = fullcomm.Get_rank()
+            strata_comm = None
+            cylinder_index, cylinder_rank = rank_to_cylinder(global_rank, rank_counts)
+            cylinder_comm = fullcomm.Split(key=global_rank, color=cylinder_index)
+            strata_rank = cylinder_index
+        else:
+            strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
+            strata_rank = strata_comm.Get_rank()
+            cylinder_rank = cylinder_comm.Get_rank()
 
         spcomm_dict = communicator_list[strata_rank]
 

--- a/mpisppy/spin_the_wheel.py
+++ b/mpisppy/spin_the_wheel.py
@@ -12,6 +12,7 @@ from mpisppy import haveMPI, global_toc, MPI
 
 from mpisppy.utils import nice_join
 from mpisppy.utils.sputils import first_stage_nonant_writer, scenario_tree_solution_writer
+from mpisppy.utils.rank_apportionment import apportion_ranks
 
 class WheelSpinner:
 
@@ -103,6 +104,27 @@ class WheelSpinner:
 
         # Create the necessary communicators
         fullcomm = comm_world
+
+        # Flexible rank assignments: each cylinder may request a rank ratio
+        # relative to the hub (default 1.0) via a "rank_ratio" dict key. The
+        # uniform case (all ratios 1.0) is handled exactly as before. A
+        # non-uniform request is apportioned (largest-remainder, floor of one)
+        # and reported, but building the communicators for unequal per-cylinder
+        # counts is not yet wired into the communicator/window layer.
+        rank_ratios = [d.get("rank_ratio", 1.0) for d in communicator_list]
+        if any(r != 1.0 for r in rank_ratios):
+            rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
+            global_toc(
+                f"Requested per-cylinder rank ratios {rank_ratios} -> "
+                f"rank counts {rank_counts}",
+                fullcomm.Get_rank() == 0,
+            )
+            raise NotImplementedError(
+                "Per-cylinder rank counts (flexible rank assignments) are not "
+                f"yet wired into the communicator layer; computed allocation "
+                f"{rank_counts}. Run with all rank_ratio == 1.0 for now."
+            )
+
         strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
         strata_rank = strata_comm.Get_rank()
         cylinder_rank = cylinder_comm.Get_rank()

--- a/mpisppy/tests/test_flexible_rank_cylinders.py
+++ b/mpisppy/tests/test_flexible_rank_cylinders.py
@@ -1,0 +1,139 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end integration test for the unequal-rank communication layer.
+
+Runs farmer with a PH hub and an xhatshuffle spoke at *unequal* rank counts.
+This is the clean Phase-2 case: of the local-sized per-scenario fields, only
+NONANTS_VALS crosses cylinders (hub -> spoke, multi-source assembly). The PH
+hub receives only scalar bounds back from the xhatshuffle spoke, so no DUALS
+(strict coherence) or xhat circular-buffer assembly is involved -- those are
+later phases.
+
+The xhatshuffle spoke reaches a good incumbent only if it reconstructs the
+hub's per-scenario nonant values correctly through the multi-source overlap
+assembly; a misrouted or torn read would feed it garbage candidates. We pin
+correctness two ways, both using fullcomm windows (so neither depends on the
+shared-memory-on-a-split-subcommunicator path, which some MPI builds reject):
+
+  * 4+2 vs 2+4: the same problem solved with the hub larger than the spoke and
+    vice versa. These exercise opposite asymmetry directions -- a spoke rank
+    stitching several hub buffers, and a spoke rank reading a sub-range of one
+    -- yet must reach the same inner bound. (No magic constant.)
+  * both must reach the extensive-form optimum (ground truth) within a loose
+    tolerance.
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_cylinders.py
+"""
+
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+# Extensive-form optimum for farmer with NUM_SCENS=10 (a deterministic LP
+# optimum, solver-independent). Regenerate with mpisppy.opt.ef.ExtensiveForm on
+# one rank if the farmer example ever changes.
+EF_OPT = -122146.70
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    # Fresh cfg/dicts per run: WheelSpinner.run mutates the dicts (key
+    # renaming) and may only run once, so each run needs its own.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.xhatshuffle_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    xhatshuffle_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [xhatshuffle_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    # Bounds are populated on the hub ranks (strata_rank 0); broadcast the
+    # lead hub rank's values so all ranks can assert in lockstep.
+    if wheel.global_rank == 0:
+        payload = (wheel.BestInnerBound, wheel.BestOuterBound)
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankCylinders(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 50
+
+    def test_unequal_rank_both_directions_agree_and_are_optimal(self):
+        # 4-rank hub, 2-rank spoke: each spoke rank stitches NONANTS_VALS from
+        # several hub buffers (multi-segment assembly).
+        ib_42, ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)
+        # 2-rank hub, 4-rank spoke: each spoke rank reads a sub-range of one
+        # hub buffer (the other asymmetry direction).
+        ib_24, ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)
+
+        # Finite incumbents (a torn/garbage read would give inf or error out).
+        self.assertTrue(abs(ib_42) < float("inf"))
+        self.assertTrue(abs(ib_24) < float("inf"))
+
+        # Both asymmetry directions reach the same inner bound.
+        self.assertLess(
+            abs(ib_42 - ib_24), 1e-3 * abs(ib_42),
+            msg=f"4+2 inner bound {ib_42} disagrees with 2+4 {ib_24}",
+        )
+
+        # ...and that bound is the extensive-form optimum (within 1%).
+        for ib in (ib_42, ib_24):
+            self.assertLess(
+                abs(ib - EF_OPT), 1e-2 * abs(EF_OPT),
+                msg=f"inner bound {ib} is not near the EF optimum {EF_OPT}",
+            )
+
+        # Valid bracketing for the (minimizing) farmer objective.
+        self.assertLessEqual(ob_42, ib_42 + 1e-6)
+        self.assertLessEqual(ob_24, ib_24 + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_ratios.py
+++ b/mpisppy/tests/test_flexible_rank_ratios.py
@@ -1,0 +1,75 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""WheelSpinner reads per-cylinder rank_ratio dict keys and, when any is
+non-default, apportions and reports the allocation then raises (the live
+unequal-rank communicator path is not yet wired in). The uniform default
+path is exercised by the cylinder test suite, not here.
+
+WheelSpinner raises before any communicator is built, so a stub comm with
+just Get_size/Get_rank is enough to reach that point without MPI."""
+
+import unittest
+
+from mpisppy.spin_the_wheel import WheelSpinner
+
+
+class _StubComm:
+    """Minimal comm: WheelSpinner only needs size and rank before it raises."""
+    def __init__(self, size, rank=0):
+        self._size = size
+        self._rank = rank
+
+    def Get_size(self):
+        return self._size
+
+    def Get_rank(self):
+        return self._rank
+
+
+def _min_dict(role, **extra):
+    # Dicts only need the keys WheelSpinner validates before it raises;
+    # the classes are never instantiated on this path.
+    d = {f"{role}_class": object, "opt_class": object}
+    d.update(extra)
+    return d
+
+
+class TestFlexibleRankRatios(unittest.TestCase):
+
+    def test_nonuniform_ratio_raises_not_implemented(self):
+        hub = _min_dict("hub", rank_ratio=1.0)
+        spoke = _min_dict("spoke", rank_ratio=0.5)
+        ws = WheelSpinner(hub, [spoke])
+        with self.assertRaises(NotImplementedError):
+            ws.run(comm_world=_StubComm(size=4))
+
+    def test_nonuniform_with_too_few_ranks_raises_value_error(self):
+        # When even the floor-of-one is infeasible, apportion_ranks raises
+        # ValueError first, before the unequal-rank NotImplementedError.
+        hub = _min_dict("hub", rank_ratio=1.0)
+        spoke_a = _min_dict("spoke", rank_ratio=0.5)
+        spoke_b = _min_dict("spoke", rank_ratio=0.5)
+        ws = WheelSpinner(hub, [spoke_a, spoke_b])
+        with self.assertRaises(ValueError):
+            ws.run(comm_world=_StubComm(size=2))
+
+    def test_explicit_uniform_ratios_proceed(self):
+        # All ratios 1.0 -> no unequal-rank raise; the next step (_make_comms)
+        # is reached and fails on the stub (no Split). Reaching that point at
+        # all proves WheelSpinner did not raise NotImplementedError.
+        hub = _min_dict("hub", rank_ratio=1.0)
+        spoke = _min_dict("spoke", rank_ratio=1.0)
+        ws = WheelSpinner(hub, [spoke])
+        with self.assertRaises(Exception) as ctx:
+            ws.run(comm_world=_StubComm(size=2))
+        self.assertNotIsInstance(ctx.exception, NotImplementedError)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_ratios.py
+++ b/mpisppy/tests/test_flexible_rank_ratios.py
@@ -6,13 +6,23 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""WheelSpinner reads per-cylinder rank_ratio dict keys and, when any is
-non-default, apportions and reports the allocation then raises (the live
-unequal-rank communicator path is not yet wired in). The uniform default
-path is exercised by the cylinder test suite, not here.
+"""WheelSpinner's flexible-rank branch (the equal-vs-unequal decision in
+``run``), exercised without MPI via a stub comm.
 
-WheelSpinner raises before any communicator is built, so a stub comm with
-just Get_size/Get_rank is enough to reach that point without MPI."""
+Phase 1 walled the unequal path off behind a NotImplementedError; the
+communication-layer cut removes that wall and builds per-cylinder
+communicators instead. These tests pin the surviving startup behavior that
+needs no MPI:
+
+  * an infeasible request (more cylinders than ranks) still errors early,
+    from apportion_ranks, before any communicator is built; and
+  * a feasible non-uniform request is no longer rejected -- it proceeds past
+    the (now removed) gate into communicator construction, where the bare
+    stub (which has no Split) fails with something *other* than
+    NotImplementedError.
+
+The full unequal path is exercised end to end by the mpiexec integration
+test; here we only need Get_size/Get_rank to drive the branch decision."""
 
 import unittest
 
@@ -20,7 +30,8 @@ from mpisppy.spin_the_wheel import WheelSpinner
 
 
 class _StubComm:
-    """Minimal comm: WheelSpinner only needs size and rank before it raises."""
+    """Minimal comm: the branch decision only needs size and rank. It has no
+    Split, so reaching communicator construction surfaces as AttributeError."""
     def __init__(self, size, rank=0):
         self._size = size
         self._rank = rank
@@ -33,25 +44,19 @@ class _StubComm:
 
 
 def _min_dict(role, **extra):
-    # Dicts only need the keys WheelSpinner validates before it raises;
+    # Dicts only need the keys WheelSpinner validates before the branch;
     # the classes are never instantiated on this path.
     d = {f"{role}_class": object, "opt_class": object}
     d.update(extra)
     return d
 
 
-class TestFlexibleRankRatios(unittest.TestCase):
-
-    def test_nonuniform_ratio_raises_not_implemented(self):
-        hub = _min_dict("hub", rank_ratio=1.0)
-        spoke = _min_dict("spoke", rank_ratio=0.5)
-        ws = WheelSpinner(hub, [spoke])
-        with self.assertRaises(NotImplementedError):
-            ws.run(comm_world=_StubComm(size=4))
+class TestFlexibleRankBranch(unittest.TestCase):
 
     def test_nonuniform_with_too_few_ranks_raises_value_error(self):
-        # When even the floor-of-one is infeasible, apportion_ranks raises
-        # ValueError first, before the unequal-rank NotImplementedError.
+        # Two 0.5-ratio spokes + a hub is three cylinders; with only two ranks
+        # the floor-of-one is infeasible, so apportion_ranks raises ValueError
+        # before any communicator construction is attempted.
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke_a = _min_dict("spoke", rank_ratio=0.5)
         spoke_b = _min_dict("spoke", rank_ratio=0.5)
@@ -59,10 +64,21 @@ class TestFlexibleRankRatios(unittest.TestCase):
         with self.assertRaises(ValueError):
             ws.run(comm_world=_StubComm(size=2))
 
-    def test_explicit_uniform_ratios_proceed(self):
-        # All ratios 1.0 -> no unequal-rank raise; the next step (_make_comms)
-        # is reached and fails on the stub (no Split). Reaching that point at
-        # all proves WheelSpinner did not raise NotImplementedError.
+    def test_nonuniform_no_longer_raises_not_implemented(self):
+        # A feasible non-uniform request used to raise NotImplementedError.
+        # Now it proceeds to build communicators; on the bare stub (no Split)
+        # that surfaces as some other exception -- proving the gate is gone.
+        hub = _min_dict("hub", rank_ratio=1.0)
+        spoke = _min_dict("spoke", rank_ratio=0.5)
+        ws = WheelSpinner(hub, [spoke])
+        with self.assertRaises(Exception) as ctx:
+            ws.run(comm_world=_StubComm(size=4))
+        self.assertNotIsInstance(ctx.exception, NotImplementedError)
+
+    def test_uniform_ratios_use_equal_path(self):
+        # All ratios 1.0 -> equal path; reaches _make_comms and fails on the
+        # stub (no Split). Reaching that point at all confirms the unequal
+        # branch was not taken and nothing raised NotImplementedError.
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke = _min_dict("spoke", rank_ratio=1.0)
         ws = WheelSpinner(hub, [spoke])

--- a/mpisppy/tests/test_overlap_map.py
+++ b/mpisppy/tests/test_overlap_map.py
@@ -1,0 +1,115 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unit tests for mpisppy.cylinders.overlap_map.compute_overlap_segments."""
+
+import unittest
+
+from mpisppy.cylinders.overlap_map import OverlapSegment, compute_overlap_segments
+
+
+def _seg(remote_rank, remote_offset, local_offset, count):
+    return OverlapSegment(remote_rank, remote_offset, local_offset, count)
+
+
+class TestOverlapMap(unittest.TestCase):
+
+    def _assert_tiles_local(self, segments, local_scen_idxs, items_per_scen):
+        # Segments must tile the local buffer contiguously from offset 0,
+        # with total length equal to the local rank's item count.
+        expected_local = sum(items_per_scen[s] for s in local_scen_idxs)
+        running = 0
+        for seg in segments:
+            self.assertEqual(seg.local_offset, running)
+            running += seg.count
+        self.assertEqual(running, expected_local)
+
+    def test_equal_ranks_is_identity_single_segment(self):
+        # Same rank count on both cylinders -> one identity segment per
+        # local rank (the no-op-at-equal-ranks backbone).
+        remote_slices = [[0, 1], [2, 3], [4, 5], [6, 7]]
+        items = [1] * 8
+        for rank, local in enumerate(remote_slices):
+            segs = compute_overlap_segments(local, remote_slices, items)
+            self.assertEqual(segs, [_seg(rank, 0, 0, len(local))])
+
+    def test_equal_ranks_identity_multi_item(self):
+        # Identity holds with >1 item per scenario.
+        remote_slices = [[0, 1], [2, 3]]
+        items = [2] * 4
+        segs = compute_overlap_segments([2, 3], remote_slices, items)
+        self.assertEqual(segs, [_seg(1, 0, 0, 4)])
+
+    def test_fewer_remote_ranks_doc_example(self):
+        # 4-rank hub reading a 2-rank spoke, 10 scenarios, 1 item each.
+        # Spoke split is contiguous: rank0 = scen0-4, rank1 = scen5-9.
+        remote_slices = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+        items = [1] * 10
+
+        # Hub rank holding scen0,1: wholly inside spoke rank 0.
+        self.assertEqual(
+            compute_overlap_segments([0, 1], remote_slices, items),
+            [_seg(0, 0, 0, 2)],
+        )
+        # Hub rank holding scen4,5: straddles the spoke split -> two
+        # segments (scen4 from spoke rank0 @offset4, scen5 from spoke
+        # rank1 @offset0).
+        self.assertEqual(
+            compute_overlap_segments([4, 5], remote_slices, items),
+            [_seg(0, 4, 0, 1), _seg(1, 0, 1, 1)],
+        )
+        # Hub rank holding scen7,8,9: wholly inside spoke rank1, coalesced.
+        self.assertEqual(
+            compute_overlap_segments([7, 8, 9], remote_slices, items),
+            [_seg(1, 2, 0, 3)],
+        )
+
+    def test_more_remote_ranks(self):
+        # 2-rank local cylinder reading a 4-rank remote cylinder.
+        remote_slices = [[0, 1], [2, 3, 4], [5, 6], [7, 8, 9]]
+        items = [1] * 10
+        segs = compute_overlap_segments([0, 1, 2, 3, 4], remote_slices, items)
+        self.assertEqual(segs, [_seg(0, 0, 0, 2), _seg(1, 0, 2, 3)])
+        self._assert_tiles_local(segs, [0, 1, 2, 3, 4], items)
+
+    def test_coalesces_contiguous_run_within_remote_rank(self):
+        remote_slices = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+        items = [1] * 10
+        segs = compute_overlap_segments([2, 3, 4], remote_slices, items)
+        self.assertEqual(segs, [_seg(0, 2, 0, 3)])
+
+    def test_variable_items_per_scenario(self):
+        # Multistage-style: scenarios contribute different item counts.
+        items = [1, 2, 3, 1, 2]
+        remote_slices = [[0, 1, 2], [3, 4]]
+        # Local rank holds scen1,2 (both in remote rank0). scen1 starts at
+        # remote offset items[0]=1; coalesced count = 2+3 = 5.
+        segs = compute_overlap_segments([1, 2], remote_slices, items)
+        self.assertEqual(segs, [_seg(0, 1, 0, 5)])
+        self._assert_tiles_local(segs, [1, 2], items)
+
+    def test_variable_items_across_remote_ranks(self):
+        items = [1, 2, 3, 1, 2]
+        remote_slices = [[0, 1], [2, 3, 4]]
+        # Local holds scen1 (remote rank0 @offset1, count2) then scen2
+        # (remote rank1 @offset0, count3).
+        segs = compute_overlap_segments([1, 2], remote_slices, items)
+        self.assertEqual(segs, [_seg(0, 1, 0, 2), _seg(1, 0, 2, 3)])
+        self._assert_tiles_local(segs, [1, 2], items)
+
+    def test_single_scenario(self):
+        remote_slices = [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]]
+        items = [1] * 10
+        self.assertEqual(
+            compute_overlap_segments([6], remote_slices, items),
+            [_seg(1, 1, 0, 1)],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_rank_apportionment.py
+++ b/mpisppy/tests/test_rank_apportionment.py
@@ -6,11 +6,16 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""Unit tests for mpisppy.utils.rank_apportionment.apportion_ranks."""
+"""Unit tests for mpisppy.utils.rank_apportionment: apportion_ranks plus the
+contiguous-block layout helpers cylinder_bases and rank_to_cylinder."""
 
 import unittest
 
-from mpisppy.utils.rank_apportionment import apportion_ranks
+from mpisppy.utils.rank_apportionment import (
+    apportion_ranks,
+    cylinder_bases,
+    rank_to_cylinder,
+)
 
 
 class TestApportionRanks(unittest.TestCase):
@@ -104,6 +109,49 @@ class TestApportionRanks(unittest.TestCase):
         a = apportion_ranks([1.0, 0.5, 0.25], 14)
         b = apportion_ranks([0.25, 0.5, 1.0], 14)
         self.assertEqual(a, list(reversed(b)))
+
+
+class TestContiguousBlockLayout(unittest.TestCase):
+    """cylinder_bases / rank_to_cylinder define the contiguous global-rank
+    block layout used by the unequal-rank path."""
+
+    def test_bases_doc_example(self):
+        # 8 / 4 / 2 -> blocks start at 0, 8, 12.
+        self.assertEqual(cylinder_bases([8, 4, 2]), [0, 8, 12])
+
+    def test_bases_single_cylinder(self):
+        self.assertEqual(cylinder_bases([5]), [0])
+
+    def test_rank_to_cylinder_doc_example(self):
+        counts = [8, 4, 2]
+        # hub block 0..7
+        self.assertEqual(rank_to_cylinder(0, counts), (0, 0))
+        self.assertEqual(rank_to_cylinder(7, counts), (0, 7))
+        # lagrangian block 8..11
+        self.assertEqual(rank_to_cylinder(8, counts), (1, 0))
+        self.assertEqual(rank_to_cylinder(11, counts), (1, 3))
+        # xhat block 12..13
+        self.assertEqual(rank_to_cylinder(12, counts), (2, 0))
+        self.assertEqual(rank_to_cylinder(13, counts), (2, 1))
+
+    def test_rank_to_cylinder_covers_every_rank(self):
+        # Every global rank maps to exactly one (cylinder, local rank), and
+        # the local ranks within a cylinder are 0..count-1 in order.
+        counts = [3, 1, 2, 4]
+        bases = cylinder_bases(counts)
+        seen = {c: [] for c in range(len(counts))}
+        for gr in range(sum(counts)):
+            cyl, local = rank_to_cylinder(gr, counts)
+            self.assertEqual(gr, bases[cyl] + local)
+            seen[cyl].append(local)
+        for cyl, count in enumerate(counts):
+            self.assertEqual(seen[cyl], list(range(count)))
+
+    def test_rank_to_cylinder_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            rank_to_cylinder(14, [8, 4, 2])
+        with self.assertRaises(ValueError):
+            rank_to_cylinder(-1, [8, 4, 2])
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_rank_apportionment.py
+++ b/mpisppy/tests/test_rank_apportionment.py
@@ -1,0 +1,110 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unit tests for mpisppy.utils.rank_apportionment.apportion_ranks."""
+
+import unittest
+
+from mpisppy.utils.rank_apportionment import apportion_ranks
+
+
+class TestApportionRanks(unittest.TestCase):
+
+    def test_equal_ratios_divisible(self):
+        # Clean split when ranks divide evenly among equal cylinders.
+        self.assertEqual(apportion_ranks([1.0, 1.0, 1.0], 9), [3, 3, 3])
+
+    def test_equal_ratios_indivisible_breaks_ties_by_order(self):
+        # 10 ranks, 3 equal cylinders: each floors to 3 (sum 9), and the
+        # single leftover goes to the lowest-index cylinder on the tie.
+        self.assertEqual(apportion_ranks([1.0, 1.0, 1.0], 10), [4, 3, 3])
+
+    def test_two_equal_cylinders_tie(self):
+        # 3 ranks, 2 equal cylinders: shares 1.5 / 1.5, leftover -> idx 0.
+        self.assertEqual(apportion_ranks([1.0, 1.0], 3), [2, 1])
+
+    def test_design_doc_example(self):
+        # The worked example from the design doc: hub 1.0, lagrangian 0.5,
+        # xhat 0.25, np 14  ->  8 / 4 / 2 (exact, no remainder).
+        self.assertEqual(apportion_ranks([1.0, 0.5, 0.25], 14), [8, 4, 2])
+
+    def test_ratio_scale_invariance(self):
+        # Only relative magnitudes matter.
+        self.assertEqual(
+            apportion_ranks([4.0, 2.0, 1.0], 14),
+            apportion_ranks([1.0, 0.5, 0.25], 14),
+        )
+
+    def test_floor_of_one_enforced(self):
+        # A tiny ratio would round to zero; the floor-of-one pass rescues it
+        # by taking a rank from the largest cylinder.
+        counts = apportion_ranks([10.0, 0.01], 3)
+        self.assertEqual(counts, [2, 1])
+
+    def test_floor_of_one_many_small(self):
+        # Several near-zero cylinders all get rescued to 1.
+        counts = apportion_ranks([100.0, 0.001, 0.001, 0.001], 7)
+        self.assertEqual(sum(counts), 7)
+        self.assertTrue(all(c >= 1 for c in counts))
+        self.assertEqual(counts[0], 4)  # big cylinder keeps the rest
+
+    def test_cylinders_equal_ranks(self):
+        # C == n_proc: everyone gets exactly one.
+        self.assertEqual(apportion_ranks([1.0, 2.0, 3.0], 3), [1, 1, 1])
+
+    def test_single_cylinder_gets_all(self):
+        self.assertEqual(apportion_ranks([1.0], 5), [5])
+
+    def test_more_cylinders_than_ranks_raises(self):
+        with self.assertRaises(ValueError):
+            apportion_ranks([1.0, 1.0, 1.0, 1.0], 3)
+
+    def test_invalid_inputs_raise(self):
+        with self.assertRaises(ValueError):
+            apportion_ranks([], 4)
+        with self.assertRaises(ValueError):
+            apportion_ranks([1.0, 1.0], 0)
+        with self.assertRaises(ValueError):
+            apportion_ranks([1.0, -1.0], 4)
+        with self.assertRaises(ValueError):
+            apportion_ranks([1.0, 0.0], 4)
+
+    def test_invariants_over_many_cases(self):
+        # Property sweep: counts always sum to n_proc, are all >= 1, and
+        # match the cylinder count.
+        ratio_pools = [
+            [1.0, 1.0, 1.0],
+            [1.0, 0.5, 0.25],
+            [3.0, 1.0],
+            [5.0, 2.0, 2.0, 1.0],
+            [1.0, 1.0, 1.0, 1.0, 1.0],
+        ]
+        for ratios in ratio_pools:
+            for n_proc in range(len(ratios), len(ratios) + 25):
+                counts = apportion_ranks(ratios, n_proc)
+                self.assertEqual(len(counts), len(ratios))
+                self.assertEqual(sum(counts), n_proc)
+                self.assertTrue(all(c >= 1 for c in counts),
+                                msg=f"{ratios=} {n_proc=} -> {counts=}")
+
+    def test_monotone_in_ratio(self):
+        # With enough ranks, a larger ratio never gets fewer ranks than a
+        # smaller one (sanity on the apportionment ordering).
+        counts = apportion_ranks([3.0, 2.0, 1.0], 30)
+        self.assertGreaterEqual(counts[0], counts[1])
+        self.assertGreaterEqual(counts[1], counts[2])
+
+    def test_order_preserved(self):
+        # Output position i corresponds to input ratio i.
+        a = apportion_ranks([1.0, 0.5, 0.25], 14)
+        b = apportion_ranks([0.25, 0.5, 1.0], 14)
+        self.assertEqual(a, list(reversed(b)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_spwindow_multisource.py
+++ b/mpisppy/tests/test_spwindow_multisource.py
@@ -1,0 +1,133 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Low-level multi-source RMA assembly test for the unequal-rank path.
+
+This exercises the dangerous part of the communication-layer cut -- real
+passive-target one-sided RMA reads assembled from several remote ranks via
+an overlap map -- in isolation from the hub/spoke stack. It builds an
+``SPWindow`` directly on ``COMM_WORLD``, has a "writer" cylinder publish
+known per-scenario values, and has a smaller "reader" cylinder reconstruct
+its own scenarios' values with ``compute_overlap_segments`` + partial
+``SPWindow.get`` reads. A reader rank whose scenarios straddle a writer-rank
+boundary must stitch the result from two writer buffers; that is the case the
+plain single-source reader cannot handle and the multi-source path must.
+
+Run with: ``mpiexec -np 6 python -m mpi4py -m pytest <thisfile>`` (or via the
+straight_tests / coverage harness, which launches mpiexec for it).
+"""
+
+import unittest
+
+import numpy as np
+
+from mpisppy import MPI
+from mpisppy.cylinders.spwindow import Field, SPWindow, padded_len_n_doubles
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+
+fullcomm = MPI.COMM_WORLD
+global_rank = fullcomm.Get_rank()
+global_size = fullcomm.Get_size()
+
+
+def _contiguous_slices(n_scen, n_proc):
+    """Contiguous per-rank scenario partition, matching the formula used by
+    sputils._ScenTree.scen_names_to_ranks (rank -> list of global scen idxs)."""
+    avg = n_scen / n_proc
+    return [list(range(int(i * avg), int((i + 1) * avg))) for i in range(n_proc)]
+
+
+def _scen_value(scen, item):
+    """A distinct, recognizable value for (global scenario, item) so a
+    misrouted read is caught rather than silently plausible."""
+    return 1000.0 * scen + item
+
+
+@unittest.skipUnless(global_size == 6, "needs exactly 6 MPI ranks (4 writers + 2 readers)")
+class TestMultiSourceAssembly(unittest.TestCase):
+    """Ranks 0-3 are a 4-rank writer cylinder; ranks 4-5 a 2-rank reader
+    cylinder. Both cover the same N_SCEN scenarios, split differently, so a
+    reader rank reads from several writer ranks."""
+
+    N_SCEN = 10
+    WRITER_RANKS = 4   # global ranks 0..3
+    READER_RANKS = 2   # global ranks 4..5
+
+    def _run_one(self, items_per_scen_k):
+        writer_slices = _contiguous_slices(self.N_SCEN, self.WRITER_RANKS)
+        reader_slices = _contiguous_slices(self.N_SCEN, self.READER_RANKS)
+        k = items_per_scen_k
+
+        is_writer = global_rank < self.WRITER_RANKS
+
+        # Every rank builds the (collective) window. Writers publish a
+        # NONANTS_VALS-like field sized to their local scenarios; readers
+        # publish nothing and only read.
+        if is_writer:
+            my_scen = writer_slices[global_rank]
+            data_len = k * len(my_scen)
+            logical_len = data_len  # data only; no id slot needed for this test
+            padded = padded_len_n_doubles(logical_len)
+            my_fields = {Field.NONANTS_VALS: (logical_len, padded)}
+        else:
+            my_fields = {}
+
+        win = SPWindow(my_fields, fullcomm)
+
+        if is_writer:
+            padded = win.buffer_layout[Field.NONANTS_VALS][2]
+            buf = np.full(padded, np.nan, dtype="d")
+            for i, scen in enumerate(my_scen):
+                for j in range(k):
+                    buf[i * k + j] = _scen_value(scen, j)
+            win.put(buf, Field.NONANTS_VALS)
+
+        # Ensure all writer puts are visible before any reader get.
+        fullcomm.Barrier()
+
+        if not is_writer:
+            reader_local = global_rank - self.WRITER_RANKS
+            my_scen = reader_slices[reader_local]
+            segments = compute_overlap_segments(
+                my_scen, writer_slices, [k] * self.N_SCEN
+            )
+            # writer cylinder's global-rank base is 0
+            local_buf = np.full(k * len(my_scen), np.nan, dtype="d")
+            for seg in segments:
+                dest = local_buf[seg.local_offset : seg.local_offset + seg.count]
+                win.get(dest, seg.remote_rank, Field.NONANTS_VALS,
+                        item_offset=seg.remote_offset, item_count=seg.count)
+
+            expected = np.array(
+                [_scen_value(scen, j) for scen in my_scen for j in range(k)],
+                dtype="d",
+            )
+            np.testing.assert_array_equal(
+                local_buf, expected,
+                err_msg=f"{global_rank=} {k=} {my_scen=} {segments=}",
+            )
+            # A straddling reader rank must have used more than one segment.
+            if reader_local == 0:
+                self.assertGreater(
+                    len(segments), 1,
+                    "reader rank 0 spans a writer-rank boundary; expected a "
+                    "multi-segment assembly",
+                )
+
+        fullcomm.Barrier()
+        win.free()
+
+    def test_assembly_one_item_per_scenario(self):
+        self._run_one(items_per_scen_k=1)
+
+    def test_assembly_multi_item_per_scenario(self):
+        self._run_one(items_per_scen_k=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_spwindow_partial_get.py
+++ b/mpisppy/tests/test_spwindow_partial_get.py
@@ -1,0 +1,82 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Partial-read support in SPWindow.get(), exercised on a single-process
+RMA window (MPI.COMM_SELF). Verifies the default whole-field read is
+unchanged and that item_offset/item_count read the right sub-range."""
+
+import unittest
+
+import numpy as np
+
+from mpisppy import MPI
+from mpisppy.cylinders.spwindow import Field, SPWindow, padded_len_n_doubles
+
+
+class TestPartialGet(unittest.TestCase):
+
+    def setUp(self):
+        self.logical = 10
+        self.padded = padded_len_n_doubles(self.logical)
+        my_fields = {Field.NONANTS_VALS: (self.logical, self.padded)}
+        self.win = SPWindow(my_fields, MPI.COMM_SELF)
+        # Known, distinct values across the whole padded field.
+        self.data = np.arange(100, 100 + self.padded, dtype="d")
+        self.win.put(self.data, Field.NONANTS_VALS)
+
+    def tearDown(self):
+        self.win.free()
+
+    def test_full_read_unchanged(self):
+        # Default args: whole padded field, as before.
+        dest = np.empty(self.padded, dtype="d")
+        self.win.get(dest, 0, Field.NONANTS_VALS)
+        np.testing.assert_array_equal(dest, self.data)
+
+    def test_partial_prefix(self):
+        dest = np.empty(3, dtype="d")
+        self.win.get(dest, 0, Field.NONANTS_VALS, item_offset=0, item_count=3)
+        np.testing.assert_array_equal(dest, self.data[0:3])
+
+    def test_partial_middle(self):
+        dest = np.empty(4, dtype="d")
+        self.win.get(dest, 0, Field.NONANTS_VALS, item_offset=2, item_count=4)
+        np.testing.assert_array_equal(dest, self.data[2:6])
+
+    def test_partial_suffix(self):
+        dest = np.empty(5, dtype="d")
+        self.win.get(dest, 0, Field.NONANTS_VALS,
+                     item_offset=self.padded - 5, item_count=5)
+        np.testing.assert_array_equal(dest, self.data[self.padded - 5:])
+
+    def test_partial_full_via_count(self):
+        # item_count equal to padded length reproduces the full read.
+        dest = np.empty(self.padded, dtype="d")
+        self.win.get(dest, 0, Field.NONANTS_VALS,
+                     item_offset=0, item_count=self.padded)
+        np.testing.assert_array_equal(dest, self.data)
+
+    def test_single_item(self):
+        dest = np.empty(1, dtype="d")
+        self.win.get(dest, 0, Field.NONANTS_VALS, item_offset=7, item_count=1)
+        self.assertEqual(dest[0], self.data[7])
+
+    def test_out_of_range_raises(self):
+        dest = np.empty(2, dtype="d")
+        with self.assertRaises(AssertionError):
+            self.win.get(dest, 0, Field.NONANTS_VALS,
+                         item_offset=self.padded - 1, item_count=2)
+
+    def test_dest_size_mismatch_raises(self):
+        dest = np.empty(5, dtype="d")  # wrong size for count=3
+        with self.assertRaises(AssertionError):
+            self.win.get(dest, 0, Field.NONANTS_VALS, item_offset=0, item_count=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/rank_apportionment.py
+++ b/mpisppy/utils/rank_apportionment.py
@@ -1,0 +1,84 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Apportion a fixed pool of MPI ranks across cylinders by target ratio.
+
+Supports flexible (per-cylinder) rank counts for WheelSpinner.  See
+``doc/designs/flexible_rank_assignments.md`` (the "User Interface"
+section) for the algorithm and its rationale.
+"""
+
+import math
+
+
+def apportion_ranks(ratios, n_proc):
+    """Apportion ``n_proc`` ranks across cylinders by target ratio.
+
+    Uses the largest-remainder (Hare quota) method, then enforces a
+    floor of one rank per cylinder.  The returned counts sum to exactly
+    ``n_proc`` and every entry is at least 1, so every cylinder runs.
+
+    Args:
+        ratios: ordered sequence of positive target ratios, one per
+            cylinder, in declaration order (the hub is conventionally
+            first with ratio 1.0).  Only relative magnitudes matter.
+        n_proc: total number of MPI ranks to distribute (> 0).
+
+    Returns:
+        list[int]: rank count per cylinder, in the same order as
+        ``ratios``, summing to ``n_proc``, each at least 1.
+
+    Raises:
+        ValueError: if there are more cylinders than ranks (a floor of
+            one each is then infeasible), or if any ratio is
+            non-positive, or if ``n_proc`` is non-positive, or if no
+            cylinders are given.
+    """
+    n_cyl = len(ratios)
+    if n_cyl == 0:
+        raise ValueError("apportion_ranks: need at least one cylinder")
+    if n_proc <= 0:
+        raise ValueError(f"apportion_ranks: n_proc must be positive (got {n_proc})")
+    if any(r <= 0 for r in ratios):
+        raise ValueError(f"apportion_ranks: ratios must be positive (got {list(ratios)})")
+    if n_cyl > n_proc:
+        raise ValueError(
+            f"apportion_ranks: {n_cyl} cylinders cannot each receive at least "
+            f"one rank from only {n_proc} ranks"
+        )
+
+    total = math.fsum(ratios)
+    real_share = [r / total * n_proc for r in ratios]
+    counts = [math.floor(x) for x in real_share]
+
+    # Largest-remainder: hand out the leftover ranks to the biggest
+    # fractional remainders, breaking ties by declaration order (lowest
+    # index first).
+    leftover = n_proc - sum(counts)
+    if leftover > 0:
+        by_remainder = sorted(
+            range(n_cyl),
+            key=lambda i: (real_share[i] - counts[i], -i),
+            reverse=True,
+        )
+        for i in by_remainder[:leftover]:
+            counts[i] += 1
+
+    # Floor of one: move a rank from the currently-largest cylinder to a
+    # cylinder stuck at zero, until none remain at zero.  This is always
+    # feasible because n_cyl <= n_proc, so whenever a zero exists some
+    # other cylinder holds at least two.
+    while True:
+        zeros = [i for i, c in enumerate(counts) if c == 0]
+        if not zeros:
+            break
+        donor = max(range(n_cyl), key=lambda i: counts[i])
+        counts[donor] -= 1
+        counts[zeros[0]] += 1
+
+    return counts

--- a/mpisppy/utils/rank_apportionment.py
+++ b/mpisppy/utils/rank_apportionment.py
@@ -82,3 +82,50 @@ def apportion_ranks(ratios, n_proc):
         counts[zeros[0]] += 1
 
     return counts
+
+
+def cylinder_bases(rank_counts):
+    """First global rank of each cylinder's contiguous block.
+
+    The unequal-rank path lays cylinders out as contiguous global-rank
+    blocks in declaration order: cylinder ``i`` owns global ranks
+    ``[bases[i], bases[i] + rank_counts[i])``.
+
+    Args:
+        rank_counts: per-cylinder rank counts (e.g. from ``apportion_ranks``).
+
+    Returns:
+        list[int]: ``bases[i]`` is the lowest global rank in cylinder ``i``.
+    """
+    bases = []
+    base = 0
+    for rc in rank_counts:
+        bases.append(base)
+        base += rc
+    return bases
+
+
+def rank_to_cylinder(global_rank, rank_counts):
+    """Locate a global rank within the contiguous-block cylinder layout.
+
+    Args:
+        global_rank: a rank in ``[0, sum(rank_counts))``.
+        rank_counts: per-cylinder rank counts (e.g. from ``apportion_ranks``).
+
+    Returns:
+        tuple[int, int]: ``(cylinder_index, rank_within_cylinder)``, where
+        ``rank_within_cylinder`` is this rank's position in its cylinder's
+        ``cylinder_comm`` (i.e. its ``cylinder_rank``).
+
+    Raises:
+        ValueError: if ``global_rank`` is outside the apportioned range.
+    """
+    base = 0
+    for cyl, rc in enumerate(rank_counts):
+        if base <= global_rank < base + rc:
+            return cyl, global_rank - base
+        base += rc
+    raise ValueError(
+        f"rank_to_cylinder: global_rank {global_rank} is outside the "
+        f"apportioned range [0, {base}) for rank_counts {list(rank_counts)}"
+    )

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -174,6 +174,14 @@ run_phase "test_dualcg_main (serial)" \
 run_phase "test_dualcg_with_cylinders (mpiexec -np 2)" \
     mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_dualcg_with_cylinders.py
 
+# Flexible (unequal) rank assignments: both need 6 ranks (4-rank + 2-rank
+# cylinders); -oversubscribe so they run on hosts with fewer than 6 cores.
+run_phase "test_spwindow_multisource (mpiexec -np 6)" \
+    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_spwindow_multisource.py
+
+run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
+    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
+
 # ---------- Tests that spawn mpiexec internally ----------
 
 PYARGS="-m coverage run --parallel-mode --rcfile=$PROJ_DIR/.coveragerc --data-file=$PROJ_DIR/.coverage"

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -121,6 +121,18 @@ run_phase "test_reduced_costs_rho_bundles (serial)" \
 run_phase "test_rho_deprecations (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_rho_deprecations.py -v
 
+run_phase "test_rank_apportionment (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_rank_apportionment.py -v
+
+run_phase "test_overlap_map (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_overlap_map.py -v
+
+run_phase "test_spwindow_partial_get (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_spwindow_partial_get.py -v
+
+run_phase "test_flexible_rank_ratios (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_ratios.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** (targets `main`)
> 2. **Phase 2: communication layer** ← _this PR_ (targets `flex-ranks-phase1-infrastructure`)
> 3. **DLWoodruff/mpi-sppy-1#13 — Phase 3a: per-field coherence (DUALS strict)** (targets `flex-ranks-phase2-communication`)
> 4. **DLWoodruff/mpi-sppy-1#14 — Phase 3b: CLI rank-ratio flags** (targets `flex-ranks-phase3-coherence`)
> 5. **DLWoodruff/mpi-sppy-1#15 — Phase 4a: two-stage xhat fields** (targets `flex-ranks-phase3b-cli`)
>
> 6. **DLWoodruff/mpi-sppy-1#16 — Phase 4b: multistage per-node xhat sourcing** (targets `flex-ranks-phase4a-xhat-2stage`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

Second phase of the flexible-rank design (`doc/designs/flexible_rank_assignments.md`).
Adds the communication layer that actually runs cylinders at unequal rank
counts. **Gated-additive: the equal-rank path is unchanged** — all of this is
reached only when a cylinder's `rank_ratio` differs from 1.0.

## What's here

- **`spin_the_wheel.py`** — on a non-uniform rank-ratio request, apportion the
  rank pool into contiguous global-rank blocks, build `cylinder_comm` only
  (no `strata_comm`, which is undefined when cylinders differ in size), and
  pass `strata_comm=None`. The phase-1 `NotImplementedError` gate is removed.
- **`rank_apportionment.py`** — `cylinder_bases` / `rank_to_cylinder` for the
  contiguous-block layout.
- **`SPCommunicator`** — when `strata_comm is None`: window on `fullcomm`,
  peers addressed by global rank. `get_receive_buffer` gains a flex dispatch —
  single-source (from a peer cylinder's base rank) for global/scalar fields,
  multi-source overlap-map assembly for per-scenario fields.
- **Layout exchange** is `fullcomm.allgather` (interim; the scalable
  two-level/local-compute replacement is a pre-advertisement release gate,
  tracked in Pyomo/mpi-sppy#726).

## Coherence — two RMA bugs found while testing (this is the flaky corner the design flags)

- **Lockstep:** consumers like `xhatshufflelooper` require every reader rank to
  agree on "is_new" so the collectives they run on new data stay matched on
  `cylinder_comm`. The multi-source reader mirrors the equal-rank cross-rank
  `write_id` agreement rather than accepting each source independently.
- **Atomicity:** each source's whole field is read in **one** `Get` (data +
  trailing `write_id` from a single snapshot), committed into the buffer only
  after the agreement check passes. Reading data and id in separate `Get`s
  raced the writer (pre-write NaN data paired with a fresh id, accepted as new).

## Tests (np=6, both on `fullcomm` windows; `-oversubscribe`)

- **`test_spwindow_multisource.py`** — builds an `SPWindow` directly on
  `COMM_WORLD` and asserts exact multi-source assembly from several remote
  ranks (incl. a reader rank straddling a writer boundary). Isolates the RMA
  primitive from the hub/spoke stack.
- **`test_flexible_rank_cylinders.py`** — farmer PH hub + xhatshuffle spoke at
  **4+2 and 2+4**. The only local-sized field crossing cylinders is
  `NONANTS_VALS`; both asymmetry directions must agree and reach the
  extensive-form optimum.

Both wired into `run_coverage.bash` and the `test-cylinders` CI job. Equal-rank
regression (`test_with_cylinders` np=2) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





