### PR TITLE
flex-ranks phase 3b: CLI --<spoke>-rank-ratio flags

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1140,7 +1140,8 @@ jobs:
             mpisppy/tests/test_overlap_map.py \
             mpisppy/tests/test_spwindow_partial_get.py \
             mpisppy/tests/test_flexible_rank_ratios.py \
-            mpisppy/tests/test_flex_coherence_policy.py
+            mpisppy/tests/test_flex_coherence_policy.py \
+            mpisppy/tests/test_flexible_rank_cli.py
 
       - name: Upload coverage data
         if: always()

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -971,6 +971,13 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 2 coverage run $COV_ARGS -m mpi4py test_with_cylinders.py
 
+      - name: run flexible (unequal) rank tests
+        timeout-minutes: 10
+        run: |
+          cd mpisppy/tests
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_spwindow_multisource.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_cylinders.py
+
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -977,6 +977,7 @@ jobs:
           cd mpisppy/tests
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_spwindow_multisource.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_cylinders.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_duals.py
 
       - name: Upload coverage data
         if: always()
@@ -1138,7 +1139,8 @@ jobs:
             mpisppy/tests/test_rank_apportionment.py \
             mpisppy/tests/test_overlap_map.py \
             mpisppy/tests/test_spwindow_partial_get.py \
-            mpisppy/tests/test_flexible_rank_ratios.py
+            mpisppy/tests/test_flexible_rank_ratios.py \
+            mpisppy/tests/test_flex_coherence_policy.py
 
       - name: Upload coverage data
         if: always()

--- a/doc/designs/flexible_rank_assignments.md
+++ b/doc/designs/flexible_rank_assignments.md
@@ -363,6 +363,25 @@ window creation.  Cons:
   over one anchor rank per cylinder — rather than a single
   `fullcomm.allgather`, which scales worse at N=thousands.
 
+  *What the communication-layer cut actually ships, and the release
+  gate.*  The first cut uses a single `fullcomm.allgather` for the
+  unequal-rank layout exchange.  This is deliberate but interim: it is
+  effectively zero new code (the existing `SPWindow` exchange run on
+  `fullcomm` instead of `strata_comm`), it is a one-time *startup* cost
+  on a cold path — not the RMA hot path — and at development/test scale
+  (a handful of ranks) it is free.  It is **not** the end state.
+  Because total rank counts in the thousands are a real operating
+  regime here, the O(N) startup allgather and its O(N)-per-rank layout
+  storage must be replaced by the two-level (or local-compute) scheme
+  **before flexible ranks is documented or recommended for production
+  use** (it can land on `main` before then, since it is inert until a
+  non-default ratio).  That replacement is its own focused change — it
+  touches only how
+  `strata_buffer_layouts` is populated at startup, not the multi-source
+  reader — so it is tracked as a release-gate item rather than folded
+  into the feature phases, letting it be reviewed and scale-tested on
+  its own.  See §Gate reliance on the feature with an MPI CI matrix.
+
   *Lock granularity.*  `MPI_Win_lock(rank=target, ...)` is per-
   target-rank in the MPI spec, not per-window — a writer's exclusive
   lock on its own buffer does not block readers fetching from a
@@ -632,9 +651,12 @@ the first pass bundled into "Phase 0" has already landed separately.
 **Phase 2: Communication layer** (additive; reached only when a ratio
 differs from 1.0)
 
-- Add a `fullcomm`-based or locally-computed layout exchange for the
-  unequal-rank path (Option D's addressing), *alongside* the existing
+- Add the `fullcomm.allgather` layout exchange for the unequal-rank
+  path (Option D's addressing), *alongside* the existing
   `strata_comm`-based exchange, which the equal-rank path keeps using.
+  This is the interim exchange; the scalable replacement is a release
+  gate, not a feature phase (see the Option D layout-exchange note and
+  §Gate reliance on the feature with an MPI CI matrix).
 - Implement multi-source `get_receive_buffer()` using overlap maps, as
   a path taken only under non-default ratios; the single-source reader
   is unchanged for the equal-rank case.
@@ -750,11 +772,20 @@ are subtle.  If isolation is ever genuinely wanted, prefer a branch in
 the upstream repository over a separate fork -- same isolation, far less
 CI and merge friction.)
 
-**Gate reliance on the feature with an MPI CI matrix.**  There is no
-default to flip, but before the `fullcomm` path is advertised as
-supported, exercise it on at least two MPI implementations (e.g. OpenMPI
-and MPICH) and more than one mpi4py / MPI version, since that path is
-where the RMA-portability risk lives.
+**Prerequisites before the feature is recommended for production use.**
+There is no default to flip, but before the `fullcomm` path is
+documented or recommended for production use, exercise it on at least
+two MPI implementations (e.g. OpenMPI and MPICH) and more than one
+mpi4py / MPI version, since that path is where the RMA-portability risk
+lives.
+
+The same "finish before recommending it" list carries the **scalable
+layout exchange**: the interim `fullcomm.allgather` (see the Option D
+layout-exchange note) must be replaced by the two-level or local-compute
+scheme before the feature is documented or recommended for production
+use, because total rank counts in the thousands are a real operating
+regime here.  Both are prerequisites for recommending the feature, not
+for landing the intervening phases on `main`.
 
 
 ### Possible future optimization (out of scope)

--- a/doc/src/building_overview.rst
+++ b/doc/src/building_overview.rst
@@ -1,0 +1,21 @@
+Overview
+========
+
+If your model is written in Pyomo, you create a Python module with the
+following functions. The remaining chapters in this section describe
+each one in detail.
+
+- ``scenario_creator`` -- builds a Pyomo model for one scenario (see :ref:`scenario_creator`)
+- ``scenario_names_creator`` -- returns the list of scenario names (see :ref:`helper_functions`)
+- ``kw_creator`` -- returns keyword arguments for the scenario creator (see :ref:`helper_functions`)
+- ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
+- ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
+
+Once you have these functions, you can use ``generic_cylinders.py``
+(see :ref:`generic_cylinders`) to solve your problem using the EF or
+the hub-and-spoke system. See the ``farmer`` directory in ``examples``
+for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+
+For models written in an algebraic modeling language other than Pyomo
+(e.g., AMPL or GAMS), see :doc:`agnostic`. For models supplied as
+SMPS-format files, see :doc:`smps`.

--- a/doc/src/code_coverage.rst
+++ b/doc/src/code_coverage.rst
@@ -46,13 +46,15 @@ arguments in each subprocess invocation. A command that would normally be:
 
 .. code-block:: text
 
-   mpiexec -np 3 python -u -m mpi4py farmer_cylinders.py --num-scens 3 ...
+   mpiexec -np 3 python -u -m mpi4py -m mpisppy.generic_cylinders \
+       --module-name farmer --num-scens 3 ...
 
 becomes:
 
 .. code-block:: text
 
-   mpiexec -np 3 python -u -m coverage run --parallel-mode --source=mpisppy -m mpi4py farmer_cylinders.py --num-scens 3 ...
+   mpiexec -np 3 python -u -m coverage run --parallel-mode --source=mpisppy \
+       -m mpi4py -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 ...
 
 Because ``--parallel-mode`` is used, each MPI rank writes its own
 ``.coverage.<hostname>.<pid>`` file. After the run, ``coverage combine``

--- a/doc/src/confidence_intervals.rst
+++ b/doc/src/confidence_intervals.rst
@@ -64,8 +64,13 @@ argument.
 These functions write ``xhat`` for the root node of the scenario tree to a file and can be read using ``read_xhat``.
 When using a cylinders driver, the function ``sputils.first_stage_nonant_npy_serializer``
 can be given as the ``first_stage_solution_writer`` argument to the function
-``sputils.write_spin_the_wheel_first_stage_solution``. See the ``farmer_cylinders.py``
-and ``farmer_ef.py`` examples. The ``uc_cylinders.py`` file also shows an example.
+``sputils.write_spin_the_wheel_first_stage_solution``. See
+``examples/farmer/CI/farmer_ef.py`` for a small EF example and
+``examples/uc/uc_cylinders.py`` for a hub-and-spoke example. From
+``generic_cylinders.py`` the incumbent xhat from a hub-and-spoke run
+can be written automatically by setting
+``--incumbent-on-improvement-filename-prefix``, which produces both
+``.csv`` and ``.npy`` files each time a better inner bound is found.
 
 Evaluating a candidate solution
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/src/drivers.rst
+++ b/doc/src/drivers.rst
@@ -49,7 +49,15 @@ Extending Examples
 Many developers
 will need to add extensions. Here are few examples:
 
-* In the ``examples.farmer.archive.farmer_cylinders.py`` example, there is a block of code to add a ``--crops-mult`` argument that is passed to the scenario creator in the ``scenario_creator_kwargs`` dictionary.
+* The model file ``examples.farmer.farmer.py`` defines an
+  ``inparser_adder`` function that registers a ``--crops-multiplier``
+  option on the ``Config``, and a ``kw_creator`` function that
+  forwards that value to the scenario creator via the
+  ``scenario_creator_kwargs`` dictionary. This is the recommended
+  pattern for adding problem-specific command-line arguments when
+  driving a model through ``generic_cylinders.py``. (For comparison,
+  the older hand-wired equivalent is preserved in
+  ``examples.farmer.archive.farmer_cylinders.py``.)
 
 * In the ``hydro_cylinders.py`` example (which has three stages). The branching factors are obtained from the command line and passed to the scenario constructor via ``scenario_creator_kwargs`` and also passed to ``sputils.create_nodenames_from_BFs`` to create a node list.
 

--- a/doc/src/ef.rst
+++ b/doc/src/ef.rst
@@ -57,7 +57,7 @@ Other method: ``mpisppy.utils.sputils.create_EF``
 -------------------------------------------------
 
 The use of this function does not require the installation of ``mpi4py``. Its use
-is illustrated in ``examples.farmer.farmer_ef.py``. Here are the
+is illustrated in ``examples.farmer.CI.farmer_ef.py``. Here are the
 arguments to the function:
 
 .. autofunction:: mpisppy.utils.sputils.create_EF

--- a/doc/src/extensions.rst
+++ b/doc/src/extensions.rst
@@ -38,7 +38,7 @@ Multiple Extensions
 To employ multiple PH extensions, use ``mpisppy.extensions.extension import MultiExtension``
 that allows you to give a list of extensions that will fire in order
 at each callout point. See, e.g. ``examples.sizes.sizes_demo.py`` or
-``examples.farmer.farmer_rho_demo.py`` for an
+``examples.farmer.CI.farmer_rho_demo.py`` for an
 example of use.
 
 .. note::
@@ -96,8 +96,8 @@ fixer.py
 This extension provides methods for fixing nonanticipative variables (usually integers) for
 which all scenarios have agreed for some number of iterations. There
 is an example of its use in ``examples.sizes.sizes_demo.py`` also
-in ``examples.sizes.uc_ama.py``. The ``uc_ama`` example illustrates
-that when ``amgalgamator`` is used ``"id_fix_list_fct"`` needs
+in ``examples.uc.uc_ama.py``. The ``uc_ama`` example illustrates
+that when ``amalgamator`` is used ``"id_fix_list_fct"`` needs
 to be on the ``Config`` object so the amalgamator can find it.
 
 .. note::
@@ -169,9 +169,11 @@ norm_rho_updater
 ^^^^^^^^^^^^^^^^
 
 This extension adjust rho dynamically. The code is in ``mpisppy.extensions.norm_rho_updater.py``
-and there is an accompanying converger in ``mpisppy.convergers.norm_rho_converger``. An
-example of use is shown in ``examples.farmer.farmer_cylinders.py``. This is
-the original Gabe H. dynamic rho.
+and there is an accompanying converger in ``mpisppy.convergers.norm_rho_converger``. From
+``generic_cylinders.py``, enable it with ``--use-norm-rho-updater``; a
+hand-wired example using the underlying classes directly is preserved in
+``examples.farmer.archive.farmer_cylinders.py``. This is the original
+Gabe H. dynamic rho.
 
 
 rho_setter
@@ -259,9 +261,10 @@ adds time and memory and is not recommended for production runs.
 
 gradient_extension
 ^^^^^^^^^^^^^^^^^^
-The gradient_extension sets gradient-based rho for PH.
-An example of its use is shown in  ``examples.farmer.farmer_rho_demo.py``
-There are options in ``cfg`` to control dynamic updates.
+The gradient_extension sets gradient-based rho for PH. From
+``generic_cylinders.py``, enable it with ``--grad-rho``; a standalone
+demo is in ``examples.farmer.CI.farmer_rho_demo.py``. There are options
+in ``cfg`` to control dynamic updates.
 
 mult_rho_updater
 ^^^^^^^^^^^^^^^^
@@ -272,7 +275,8 @@ cross-scenario cuts
 ^^^^^^^^^^^^^^^^^^^
 Two-stage models only. This extension adds cross scenario cuts as calculated
 by the cross-scenario cut spoke. See the implementation paper for details.
-An example of its use is shown in ``examples/farmer/cs_farmer.py``.
+A hand-wired example using the underlying classes is preserved in
+``examples/farmer/archive/cs_farmer.py``.
 
 
 Distributed Subproblem Presolve

--- a/doc/src/hubs.rst
+++ b/doc/src/hubs.rst
@@ -103,8 +103,11 @@ based on convergence within the hub; furthermore, convergence metrics within
 the hub can be helpful for tuning algorithms.
 
 The scenario decomposition methods (PH and APH) allow for optional
-metrics to be used as plug-ins. A pattern that can be followed is shown
-in the farmer example. The ``farmer_cylinders.py`` file has::
+metrics to be used as plug-ins. From ``generic_cylinders.py`` the
+``NormRhoConverger`` is wired in automatically when the
+``--use-norm-rho-updater`` flag is set. The underlying hand-wired
+pattern is preserved in the archived
+``examples/farmer/archive/farmer_cylinders.py``, which contains::
 
    from mpisppy.convergers.norm_rho_converger import NormRhoConverger
 

--- a/doc/src/index.rst
+++ b/doc/src/index.rst
@@ -16,6 +16,7 @@ MPI is used.
    :maxdepth: 2
    :caption: Building Your Model File
 
+   building_overview.rst
    scenario_creator.rst
    helper_functions.rst
 

--- a/doc/src/install_mpi.rst
+++ b/doc/src/install_mpi.rst
@@ -47,6 +47,17 @@ At least on some US Department of Energy (e.g., at Lawrence Livermore National L
 
 export MPICH_ASYNC_PROGRESS=1
 
-Without this setting, we have observed run-times increase by a factor of between 2 and 4, due to non-blocking point-to-point calls apparently being treated as blocking. 
+Without this setting, we have observed run-times increase by a factor of between 2 and 4, due to non-blocking point-to-point calls apparently being treated as blocking.
 
-Further, without this setting and in situations with a large number of ranks (e.g., >> 10), we have observed mpi-sppy stalling once scenario instances are created. 
+Further, without this setting and in situations with a large number of ranks (e.g., >> 10), we have observed mpi-sppy stalling once scenario instances are created.
+
+
+Other pip extras
+^^^^^^^^^^^^^^^^
+
+In addition to ``[mpi]``, mpi-sppy declares a couple of other ``pip``
+extras that can be combined with it (with commas, e.g.
+``pip install -e ".[mpi,doc]"``):
+
+* ``doc`` -- installs Sphinx and the theme used to build the documentation.
+* ``scipy`` -- installs SciPy, used by a few utilities.

--- a/doc/src/quick_start.rst
+++ b/doc/src/quick_start.rst
@@ -4,49 +4,372 @@ Quick Start
 Installation
 ------------
 
-Install from source by giving this command from the mpi-sppy repo root directory:
+We strongly recommend installing mpi-sppy from its GitHub repository rather
+than from PyPI. mpi-sppy is under active development and the PyPI release
+is almost always significantly out of date; bug fixes and new features land
+on GitHub first.
 
-::
+The repository is at https://github.com/Pyomo/mpi-sppy.
 
-   pip install -e .
+Prerequisites (all platforms)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We recommend installing from GitHub rather than pip, because
-the software is under active development and the pip version is almost
-always out of date. You can also include the extras flag ``docs`` to
-install documentation dependencies.
+* Python 3.9 or newer
+* ``git``
+* A Pyomo-compatible solver (e.g., cplex, gurobi, or xpress) for most
+  algorithms.
+* For decomposition algorithms (PH, APH, L-shaped, …): a working MPI
+  implementation and ``mpi4py``. If you only need to solve the extensive
+  form directly, MPI is *not* required.
 
+
+Install from GitHub on Linux
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Install an MPI implementation. Pick the method that matches your
+   environment:
+
+   * Debian / Ubuntu:
+
+     .. code-block:: bash
+
+        sudo apt-get update
+        sudo apt-get install -y libopenmpi-dev openmpi-bin build-essential
+
+   * Fedora / RHEL / Rocky:
+
+     .. code-block:: bash
+
+        sudo dnf install openmpi openmpi-devel
+        # then make mpicc / mpiexec visible in this shell:
+        module load mpi/openmpi-x86_64
+
+   * Conda environment (works on any Linux distro):
+
+     .. code-block:: bash
+
+        conda install -c conda-forge openmpi mpi4py
+
+     If you used the conda path, you can skip the ``[mpi]`` extra in step 3.
+
+2. Clone the repository:
+
+   .. code-block:: bash
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+
+3. Install in editable mode with the ``mpi`` extra (quote ``".[mpi]"`` so
+   shells that glob brackets, such as zsh, do not mangle it):
+
+   .. code-block:: bash
+
+      pip install -e ".[mpi]"
+
+4. Install a solver of your choice (e.g. ``pip install gurobipy``; commercial
+   solvers also need a license).
+
+5. Verify the installation (see :ref:`Verify Installation` below).
+
+
+Install from GitHub on macOS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+1. Install an MPI implementation. Two reliable paths:
+
+   * Homebrew (Intel or Apple Silicon):
+
+     .. code-block:: bash
+
+        brew install open-mpi
+
+   * Conda environment (recommended on Apple Silicon to avoid wheel/build
+     mismatches):
+
+     .. code-block:: bash
+
+        conda install -c conda-forge openmpi mpi4py
+
+     If you used the conda path, you can skip the ``[mpi]`` extra in step 3.
+
+2. Make sure command-line developer tools are present (one-time):
+
+   .. code-block:: bash
+
+      xcode-select --install
+
+3. Clone the repository:
+
+   .. code-block:: bash
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+
+4. Install in editable mode with the ``mpi`` extra (quote ``".[mpi]"`` so
+   shells that glob brackets, such as zsh -- the macOS default -- do not
+   mangle it):
+
+   .. code-block:: bash
+
+      pip install -e ".[mpi]"
+
+5. Install a solver of your choice.
+
+6. Verify the installation (see :ref:`Verify Installation` below).
+
+
+Install from GitHub on Windows
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Two installation paths are supported on Windows. Most users will have a
+substantially easier time with WSL2, because the Python+MPI ecosystem is
+developed and tested on Linux first. Native Windows with MS-MPI does work
+but breaks more often and requires more manual setup. Detailed instructions
+for both follow.
+
+Optional: notes for Visual Studio Code users
+""""""""""""""""""""""""""""""""""""""""""""
+
+**The use of VS-Code is entirely optional.** It is intended only for users
+who have already chosen to use Microsoft Visual Studio Code (VS Code) as
+their editor and want it to work smoothly with the WSL2 or MS-MPI paths
+below. You do not need VS Code to install or use mpi-sppy; any editor
+(or no editor) is fine. If you do not use VS Code, skip this subsection
+entirely and go straight to WSL2 or MS-MPI.
+
+If you *are* using VS Code, the following one-time setup pairs well with
+either installation path:
+
+1. From the Extensions panel (``Ctrl+Shift+X``), install:
+
+   * **Python** (publisher: Microsoft) -- language support, debugging,
+     interpreter selection.
+   * **Pylance** (publisher: Microsoft) -- usually installed automatically
+     with Python; provides fast type checking and autocompletion.
+   * **WSL** (publisher: Microsoft) -- only needed if you plan to use the
+     WSL2 path below. Lets VS Code open and edit files *inside* the Ubuntu
+     environment as if they were local.
+   * **Jupyter** (publisher: Microsoft) -- optional, useful if you intend
+     to use notebooks for analysis.
+
+2. After you complete the WSL2 or MS-MPI steps below and the
+   ``git clone`` step has produced an ``mpi-sppy`` folder, open it in
+   VS Code:
+
+   * **If you used WSL2:** from the Ubuntu shell, ``cd mpi-sppy`` and run
+     ``code .`` -- VS Code will launch, install its WSL server in the
+     background the first time, and open the folder. The lower-left
+     status bar should read "WSL: Ubuntu" to confirm you are editing
+     *inside* WSL, not on Windows.
+   * **If you used native MS-MPI:** open VS Code and choose
+     "File → Open Folder…", then select the cloned ``mpi-sppy`` directory.
+
+3. Select the correct Python interpreter. Open the Command Palette with
+   ``Ctrl+Shift+P``, type "Python: Select Interpreter", and press Enter.
+   Pick the interpreter from the virtual environment you created in the
+   instructions below (e.g. ``~/mpisppy-env/bin/python`` for WSL2 or
+   ``mpisppy-env\Scripts\python.exe`` for native Windows). VS Code will
+   remember this choice for the folder.
+
+4. Open an integrated terminal with ``Ctrl+` `` (Ctrl plus backtick). On
+   WSL2 this gives you the Ubuntu shell directly; on native Windows it
+   gives you PowerShell. All ``mpiexec`` and ``python`` commands shown
+   later in this document can be typed into this terminal.
+
+Continue with either WSL2 or native MS-MPI below.
+
+WSL2 (Windows Subsystem for Linux)
+""""""""""""""""""""""""""""""""""
+
+1. Install WSL2 with an Ubuntu distribution. From an *administrator*
+   PowerShell:
+
+   .. code-block:: powershell
+
+      wsl --install -d Ubuntu
+
+   Reboot if Windows asks you to, then launch the new "Ubuntu" entry from
+   the Start menu and finish the first-time user setup.
+
+2. From inside the Ubuntu shell, install Python, git, OpenMPI, and a build
+   toolchain:
+
+   .. code-block:: bash
+
+      sudo apt-get update
+      sudo apt-get install -y python3 python3-pip python3-venv git \
+          libopenmpi-dev openmpi-bin build-essential
+
+3. (Recommended) Create and activate a Python virtual environment so
+   mpi-sppy and its dependencies do not interfere with the system Python:
+
+   .. code-block:: bash
+
+      python3 -m venv ~/mpisppy-env
+      source ~/mpisppy-env/bin/activate
+
+4. Clone the repository and install:
+
+   .. code-block:: bash
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+      pip install -e ".[mpi]"
+
+5. Install your solver inside the WSL environment (e.g.
+   ``pip install gurobipy``). Commercial solver licenses generally work
+   cross-platform.
+
+6. Verify the installation (see :ref:`Verify Installation` below). All
+   ``mpiexec``/``python`` commands should be run from the Ubuntu shell, not
+   from PowerShell.
+
+Native Windows with MS-MPI
+""""""""""""""""""""""""""
+
+This path uses Microsoft MPI (MS-MPI), the standard MPI implementation on
+Windows.
+
+1. Install Python 3.9 or newer from https://www.python.org/downloads/ or
+   via Miniconda. If using the python.org installer, check
+   "Add python.exe to PATH" during install.
+
+2. Install Git for Windows from https://git-scm.com/download/win. This
+   provides ``git`` and a "Git Bash" shell (you can use either PowerShell
+   or Git Bash for the steps below).
+
+3. Install Microsoft MPI. You need *both* downloads from the Microsoft MPI
+   downloads page
+   (https://learn.microsoft.com/en-us/message-passing-interface/microsoft-mpi):
+
+   * ``msmpisetup.exe`` -- the MPI runtime (provides ``mpiexec.exe``)
+   * ``msmpisdk.msi`` -- the MPI SDK (headers/libs needed to build
+     ``mpi4py``)
+
+   After installing both, open a *new* PowerShell window and confirm that
+   ``mpiexec`` is on PATH:
+
+   .. code-block:: powershell
+
+      mpiexec -help
+
+4. (Recommended) Create and activate an isolated environment and install
+   ``mpi4py`` into it. Pick **one** of the following paths; do not mix
+   them, because ``conda install`` puts packages in the active conda
+   environment rather than a ``venv``.
+
+   * **conda-forge (simplest).** Installs a prebuilt ``mpi4py``, so you do
+     not need the MS-MPI SDK or a C++ compiler:
+
+     .. code-block:: powershell
+
+        conda create -n mpisppy-env python=3.12
+        conda activate mpisppy-env
+        conda install -c conda-forge mpi4py
+
+   * **venv + pip.** Use this only if you have the Microsoft C++ Build
+     Tools and the MS-MPI SDK installed, since pip builds ``mpi4py`` from
+     source:
+
+     .. code-block:: powershell
+
+        py -m venv mpisppy-env
+        mpisppy-env\Scripts\Activate.ps1
+        pip install mpi4py
+
+5. Clone the repository and install mpi-sppy. Note that in PowerShell the
+   square brackets in ``[mpi]`` must be quoted:
+
+   .. code-block:: powershell
+
+      git clone https://github.com/Pyomo/mpi-sppy.git
+      cd mpi-sppy
+      pip install -e ".[mpi]"
+
+6. Install your solver. The Python bindings for gurobi and cplex are
+   available natively on Windows.
+
+7. Verify the installation (see :ref:`Verify Installation` below). On
+   native Windows, use MS-MPI's ``mpiexec`` form, for example:
+
+   .. code-block:: powershell
+
+      mpiexec -n 3 python -m mpi4py mpisppy\generic_cylinders.py ...
+
+
+Install from PyPI (not recommended)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A released version of mpi-sppy is also published on PyPI:
+
+.. code-block:: bash
+
+   pip install mpi-sppy[mpi]
+
+This release typically lags the GitHub ``main`` branch by months; bug
+fixes and new features may not yet be available. We recommend the GitHub
+install above for any active research use.
+
+
+.. _Verify Installation:
 
 Verify Installation
 -------------------
 
-Verify that mpi-sppy and a solver are installed by running:
+The following three checks confirm that mpi-sppy, your solver, and (if
+you installed it) MPI are all working. The commands below are
+shell-neutral: they work in bash, zsh, the WSL2 Ubuntu shell, and
+Windows PowerShell. On native Windows, if ``python`` is not on PATH but
+the Python launcher is, substitute ``py`` for ``python``. Start from the
+top of the cloned ``mpi-sppy`` repository; step 1 changes into
+``examples/farmer`` and the remaining commands are run from there.
 
-.. code-block:: bash
+1. **mpi-sppy is importable and the CLI works.** This confirms the
+   editable install succeeded and Python can import the package.
 
-   cd examples/farmer
-   python -m mpisppy.generic_cylinders --module-name farmer --help
+   .. code-block:: text
 
+      cd examples/farmer
+      python -m mpisppy.generic_cylinders --module-name farmer --help
 
-If you intend to use decomposition (PH, APH, etc.), you also need a
-working installation of MPI and ``mpi4py``; see :ref:`Install mpi4py`.
-If you only need to solve the extensive form directly, MPI is not required.
+   You should see a long help message listing all available
+   command-line options. If you see ``ModuleNotFoundError: No module
+   named 'mpisppy'``, the install did not take effect in this
+   environment (most often a virtual-environment issue).
 
+2. **Your solver works.** Solve the farmer extensive form directly
+   with three scenarios. Substitute the solver you installed
+   (``gurobi``, ``cplex``, ``xpress``, …):
 
-What You Need to Provide
--------------------------
+   .. code-block:: text
 
-To use mpi-sppy, you create a Python module with the following functions:
+      python -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 --EF --EF-solver-name gurobi
 
-- ``scenario_creator`` -- builds a Pyomo model for one scenario (see :ref:`scenario_creator`)
-- ``scenario_names_creator`` -- returns the list of scenario names (see :ref:`helper_functions`)
-- ``kw_creator`` -- returns keyword arguments for the scenario creator (see :ref:`helper_functions`)
-- ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
-- ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
+   You should see the solver print progress and the script print an
+   optimal objective value. This check does *not* use MPI.
 
-Once you have these functions, you can use ``generic_cylinders.py``
-(see :ref:`generic_cylinders`) to solve your problem using the EF or
-the hub-and-spoke system. See the ``farmer`` directory in ``examples``
-for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+3. **MPI works** (only if you installed MPI and ``mpi4py``). Still in
+   ``examples/farmer``, run the bundled one-sided MPI test (its path is
+   given relative to ``examples/farmer``):
+
+   .. code-block:: text
+
+      mpiexec -n 2 python -m mpi4py ../../mpi_one_sided_test.py
+
+   If you see no error messages, your MPI installation should be
+   suitable. Then confirm the full hub-and-spoke flow with a short PH
+   run on farmer:
+
+   .. code-block:: text
+
+      mpiexec -n 3 python -m mpi4py -m mpisppy.generic_cylinders --module-name farmer --num-scens 3 --solver-name gurobi --max-iterations 5 --default-rho 1 --lagrangian --xhatshuffle
+
+   You should see iteration output and the run should terminate
+   normally.
+
+If you only intend to solve the extensive form directly, you can skip
+step 3 -- MPI is not required for ``--EF``. For additional MPI install
+guidance and HPC-specific tips, see :ref:`Install mpi4py`.
 
 
 Running the Farmer Example
@@ -71,10 +394,23 @@ Running the Farmer Example
 For more detail, see :ref:`generic_cylinders` and :ref:`Examples`.
 
 
-Researchers Who Want to Compare with mpi-sppy
-----------------------------------------------
+What You Need to Provide For Your Problem
+-----------------------------------------
 
-The quickest approach is to run one of the canned examples in
-subdirectories of ``examples``. Sample commands can be found in
-``examples.runall.py``. The mpi-sppy paper in MPC provides references
-for many of the examples.
+If your model is written in Pyomo, you create a Python module with the
+following functions:
+
+- ``scenario_creator`` -- builds a Pyomo model for one scenario (see :ref:`scenario_creator`)
+- ``scenario_names_creator`` -- returns the list of scenario names (see :ref:`helper_functions`)
+- ``kw_creator`` -- returns keyword arguments for the scenario creator (see :ref:`helper_functions`)
+- ``inparser_adder`` -- adds problem-specific command-line arguments (see :ref:`helper_functions`)
+- ``scenario_denouement`` -- called at termination (can be ``None``; see :ref:`helper_functions`)
+
+Once you have these functions, you can use ``generic_cylinders.py``
+(see :ref:`generic_cylinders`) to solve your problem using the EF or
+the hub-and-spoke system. See the ``farmer`` directory in ``examples``
+for a complete working example (``farmer.py`` and ``farmer_generic.bash``).
+
+For models written in an algebraic modeling language other than Pyomo
+(e.g., AMPL or GAMS), see :doc:`agnostic`. For models supplied as
+SMPS-format files, see :doc:`smps`.

--- a/doc/src/secretmenu.rst
+++ b/doc/src/secretmenu.rst
@@ -12,15 +12,18 @@ If the `linearize_proximal_terms` option is specified (see :ref:`linearize_proxi
 then the option 'initial_proximal_cut_count' controls
 the initial number of cuts (default 2).
 
-E.g. if you wanted to specify four cuts
-in ``examples.farmer.farmer_cylinders`` where the
-hub definition dictionary is called ``hub_dict`` you would add
+E.g. if you wanted to specify four cuts in a hand-wired driver such as
+``examples.farmer.archive.farmer_cylinders`` (where the hub definition
+dictionary is called ``hub_dict``) you would add
 
 .. code-block:: python
-                
+
    hub_dict["opt_kwargs"]["PHoptions"]["initial_proximal_cut_count"] = 4
 
-before passing ``hub_dict`` to ``spin_the_wheel``.
+before passing ``hub_dict`` to ``spin_the_wheel``. When running through
+``generic_cylinders.py`` instead, this option is not currently exposed
+as a CLI flag and must be set by modifying the configured ``hub_dict``
+in code.
 
 
 subgradient_while_waiting

--- a/doc/src/seqsamp.rst
+++ b/doc/src/seqsamp.rst
@@ -5,7 +5,7 @@ Sequential sampling
 
 Given a confidence interval, one can try to find a candidate solution
 ``xhat_one`` such that its optimality gap has this confidence interval.
-The class ``SeqSampling`` in ``mpisppy.confiden_intervals.seqsampling.py`` implements three procedures described in 
+The class ``SeqSampling`` in ``mpisppy.confidence_intervals.seqsampling.py`` implements three procedures described in
 [bm2011]_ and [bpl2012]_. It takes as an input a method to generate
 candidate solutions and options, and its ``run`` method returns a ``xhat_one`` and a confidence interval on its optimality gap.
 

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -676,11 +676,18 @@ class SPCommunicator:
         if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
             k = self.opt.nonant_length
             return [k] * len(self.opt.all_scenario_names)
+        # Reached at startup (window creation), not mid-solve: this cylinder is
+        # in a flexible-rank run and reads a per-scenario field whose
+        # multi-source assembly across unequal rank counts is not implemented
+        # yet. Fail here with an actionable message rather than mis-assembling.
         raise NotImplementedError(
-            f"multi-source assembly of {field} under unequal rank counts is "
-            f"not implemented in the communication-layer cut; only the "
-            f"per-scenario nonant fields (NONANTS_VALS, RELAXED_NONANTS_VALS, "
-            f"DUALS) are supported so far."
+            f"Flexible (unequal) rank assignments: {self.__class__.__name__} "
+            f"reads {field.name}, whose multi-source assembly across cylinders "
+            f"with different rank counts is not supported yet (only "
+            f"{Field.NONANTS_VALS.name}, {Field.RELAXED_NONANTS_VALS.name}, and "
+            f"{Field.DUALS.name} are). Run the cylinders that exchange "
+            f"{field.name} at equal rank counts (rank_ratio == 1.0), or wait "
+            f"for the phase that adds {field.name} support."
         )
 
     def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -27,8 +27,30 @@ from math import inf
 
 from mpisppy import MPI, global_toc
 from mpisppy.cylinders.spwindow import Field, FieldLengths, SPWindow, padded_len_n_doubles
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+from mpisppy.utils.rank_apportionment import (
+    apportion_ranks,
+    cylinder_bases,
+    rank_to_cylinder,
+)
 
 logger = logging.getLogger(__name__)
+
+# Fields whose buffer length is the same on every rank (global-sized) or a
+# fixed-size record (scalar): Categories 3 and 4 in the design doc. Under
+# unequal rank counts these are read single-source from the publishing
+# cylinder's base rank -- there is nothing to assemble. Every other field is
+# local-sized / per-scenario (Categories 1 and 2) and is read via the
+# overlap-map multi-source path.
+_GLOBAL_OR_SCALAR_FIELDS = frozenset((
+    Field.SHUTDOWN,
+    Field.OBJECTIVE_INNER_BOUND,
+    Field.OBJECTIVE_OUTER_BOUND,
+    Field.BEST_OBJECTIVE_BOUNDS,
+    Field.NONANT_LOWER_BOUNDS,
+    Field.NONANT_UPPER_BOUNDS,
+    Field.EXPECTED_REDUCED_COST,
+))
 
 def communicator_array(data_length: int):
     """
@@ -222,11 +244,30 @@ class SPCommunicator:
         self.strata_comm = strata_comm
         self.cylinder_comm = cylinder_comm
         self.communicators = communicators
-        assert len(communicators) == strata_comm.Get_size()
         self.global_rank = fullcomm.Get_rank()
-        self.strata_rank = strata_comm.Get_rank()
         self.cylinder_rank = cylinder_comm.Get_rank()
-        self.n_spokes = strata_comm.Get_size() - 1
+
+        # Flexible rank assignments (Option D in the design doc): when
+        # strata_comm is None the cylinders have unequal rank counts, so the
+        # strata grouping is undefined and the window lives on fullcomm with
+        # peers addressed by global rank via overlap maps. The cylinder index
+        # plays the role strata_rank does on the equal path -- it indexes
+        # `communicators` and marks the hub as 0 -- so we set strata_rank to it
+        # for the code paths shared with the equal-rank case.
+        self._flex_ranks = strata_comm is None
+        if self._flex_ranks:
+            rank_ratios = [d.get("rank_ratio", 1.0) for d in communicators]
+            self.rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
+            self._cylinder_bases = cylinder_bases(self.rank_counts)
+            self.cylinder_index, _ = rank_to_cylinder(self.global_rank, self.rank_counts)
+            self.strata_rank = self.cylinder_index
+            self.n_spokes = len(communicators) - 1
+        else:
+            assert len(communicators) == strata_comm.Get_size()
+            self.strata_rank = strata_comm.Get_rank()
+            self.cylinder_index = self.strata_rank
+            self.n_spokes = strata_comm.Get_size() - 1
+
         self.opt = spbase_object
         self.inst_time = time.time() # For diagnostics
         if options is None:
@@ -239,6 +280,11 @@ class SPCommunicator:
         self.send_buffers = {}
         # key: Field, value: list of (strata_rank, SPComm, buffer) with that Field
         self.receive_field_spcomms = {}
+
+        # Overlap-map state for the unequal-rank path; empty on the equal path.
+        # Keyed by (field, peer_cylinder_index).
+        self.overlap_maps = {}            # -> list[OverlapSegment] (global ranks)
+        self._overlap_source_ranks = {}   # -> sorted distinct source global ranks
 
         # setup FieldLengths which calculates
         # the length of each buffer type based
@@ -290,6 +336,25 @@ class SPCommunicator:
         self.fields_to_ranks = {}
         self.ranks_to_fields = {}
 
+        if self._flex_ranks:
+            # On the unequal-rank path the window spans fullcomm, so
+            # strata_buffer_layouts is indexed by global rank. Map fields to
+            # peer *cylinder* indices instead (so downstream `origin` values
+            # stay cylinder indices, as on the equal path): every rank in a
+            # cylinder registers the same send fields, so the base rank's
+            # layout names exactly the fields that cylinder publishes.
+            for peer in range(len(self.rank_counts)):
+                if peer == self.cylinder_index:
+                    continue
+                base_layout = self.window.strata_buffer_layouts[self._cylinder_bases[peer]]
+                self.ranks_to_fields[peer] = []
+                for field in base_layout.keys():
+                    if field == Field.WHOLE:
+                        continue
+                    self.fields_to_ranks.setdefault(field, []).append(peer)
+                    self.ranks_to_fields[peer].append(field)
+            return
+
         for rank, buffer_layout in enumerate(self.window.strata_buffer_layouts):
             if rank == self.strata_rank:
                 continue
@@ -337,7 +402,13 @@ class SPCommunicator:
             assert expected_logical_len == my_fa.logical_len()
             assert expected_padded_len == my_fa.padded_len()
         else:
-            self._validate_recv_field(field, origin, length)
+            # On the equal-rank path the remote buffer for `origin` has the
+            # same local sizing as ours, so we can validate it directly. On the
+            # unequal-rank path `origin` is a peer cylinder spanning several
+            # global ranks of differing sizes, so validation is per-segment
+            # (in _build_overlap_map) instead.
+            if not self._flex_ranks:
+                self._validate_recv_field(field, origin, length)
             my_fa = RecvArray(length)
             self.receive_buffers[key] = my_fa
         ## End if
@@ -393,7 +464,11 @@ class SPCommunicator:
         self.register_send_fields()
 
         window_spec = self._build_window_spec()
-        self.window = SPWindow(window_spec, self.strata_comm)
+        # Equal-rank: window on strata_comm (rank i of every cylinder),
+        # addressed by strata_rank. Unequal-rank: window on fullcomm,
+        # addressed by global rank via overlap maps (strata_comm is None).
+        window_comm = self.fullcomm if self._flex_ranks else self.strata_comm
+        self.window = SPWindow(window_spec, window_comm)
 
         self._create_field_rank_mappings()
         self.register_receive_fields()
@@ -410,6 +485,8 @@ class SPCommunicator:
         self.receive_buffers = {}
         self.send_buffers = {}
         self.receive_field_spcomms = {}
+        self.overlap_maps = {}
+        self._overlap_source_ranks = {}
 
         self.window.free()
 
@@ -424,6 +501,10 @@ class SPCommunicator:
 
     def register_receive_fields(self) -> None:
         # print(f"{self.__class__.__name__}: {self.receive_fields=}")
+        if self._flex_ranks:
+            # local global scenario indices held by this rank (its slice in
+            # its own cylinder's partition); used to build overlap maps
+            self._local_scen_idxs = list(self.opt._rank_slices[self.cylinder_rank])
         for field in self.receive_fields:
             # NOTE: If this list is empty after this method, it is up
             #       to the caller to raise an error. Sometimes optional
@@ -437,6 +518,12 @@ class SPCommunicator:
                 if field != Field.WHOLE and field in self.ranks_to_fields[strata_rank]:
                     buff = self.register_recv_field(field, strata_rank)
                     self.receive_field_spcomms[field].append((strata_rank, cls, buff))
+                    # On the unequal-rank path, a per-scenario (local-sized)
+                    # field is assembled from several remote buffers; precompute
+                    # its overlap map now. Global/scalar fields are read
+                    # single-source and need no map.
+                    if self._flex_ranks and field not in _GLOBAL_OR_SCALAR_FIELDS:
+                        self._build_overlap_map(field, strata_rank)
 
     def put_send_buffer(self, buf: SendArray, field: Field):
         """ Put the specified values into the specified locally-owned buffer
@@ -448,6 +535,42 @@ class SPCommunicator:
         buf._next_write_id()
         self.window.put(buf.window_array(), field)
         return
+
+    def _write_ids_agree(self, new_id: int, synchronize: bool) -> bool:
+        """Cross-rank write_id agreement on ``cylinder_comm`` (shared by every
+        reader: the equal-rank path and both unequal-rank helpers).
+
+        Consumers that run collectives on freshly-received data (Eobjective
+        Allreduce, ROOT bcast, ...) must enter them in lockstep, so every reader
+        rank has to agree on whether a read is "new". A synchronous writer
+        stamps all of its ranks at one write_id, so when ids agree every rank
+        computes the same answer; a transient mixed-id read (the writer Put
+        between two readers' Gets) fails here and is rejected, to be retried,
+        rather than accepted out of lockstep.
+
+        Returns True if not synchronizing, or if all ranks read the same id.
+        """
+        if not synchronize:
+            return True
+        local_val = np.array((new_id,), 'i')
+        sum_ids = np.zeros(1, 'i')
+        self.cylinder_comm.Allreduce((local_val, MPI.INT),
+                                     (sum_ids, MPI.INT),
+                                     op=MPI.SUM)
+        return new_id * self.cylinder_comm.size == sum_ids[0]
+
+    def _mark_new(self, buf: RecvArray, new_id: int) -> bool:
+        """Commit an accepted read: stamp ``new_id`` into the buffer's id slot
+        and mark it new. The data itself must already be in ``buf`` (placed by
+        the caller's single Get, or by overlap-map assembly for a multi-source
+        read). Writing the id slot before ``_pull_id`` lets the multi-source
+        path -- whose assembly fills only the data region -- reuse the same
+        commit as the single-source/equal-rank paths.
+        """
+        buf._is_new = True
+        buf._array[-1] = new_id
+        buf._pull_id()
+        return True
 
     def get_receive_buffer(self,
                            buf: RecvArray,
@@ -471,6 +594,15 @@ class SPCommunicator:
             is_new (bool): Indicates whether the "gotten" values are new,
                 based on the write_id.
         """
+        if self._flex_ranks:
+            # Unequal-rank path: `origin` is a peer cylinder index. A
+            # per-scenario field is assembled from several of that cylinder's
+            # global ranks via its overlap map; a global/scalar field is read
+            # single-source from the cylinder's base rank.
+            if (field, origin) in self.overlap_maps:
+                return self._flex_get_multi_source(buf, field, origin, synchronize)
+            return self._flex_get_single_source(buf, field, origin, synchronize)
+
         if synchronize:
             self.cylinder_comm.Barrier()
 
@@ -480,23 +612,158 @@ class SPCommunicator:
 
         new_id = int(buf.array()[-1])  # logical view
 
-        if synchronize:
-            local_val = np.array((new_id,), 'i')
-            sum_ids = np.zeros(1, 'i')
-            self.cylinder_comm.Allreduce((local_val, MPI.INT),
-                                         (sum_ids, MPI.INT),
-                                         op=MPI.SUM)
-            if new_id * self.cylinder_comm.size != sum_ids[0]:
-                buf._is_new = False
-                return False
-
-        if new_id > last_id:
-            buf._is_new = True
-            buf._pull_id()
-            return True
-        else:
+        if not self._write_ids_agree(new_id, synchronize):
             buf._is_new = False
             return False
+
+        if new_id > last_id:
+            # data is already in buf from the Get above
+            return self._mark_new(buf, new_id)
+        buf._is_new = False
+        return False
+
+    # ------------------------------------------------------------------
+    # Unequal-rank (Option D) helpers. These are reached only when
+    # self._flex_ranks is True; the equal-rank path above never calls them.
+    # ------------------------------------------------------------------
+
+    def _items_per_scen_for_field(self, field: Field):
+        """Number of field items each scenario contributes, indexed by global
+        scenario index, for a per-scenario field (used to build overlap maps).
+
+        For the nonant-valued fields this is the per-scenario nonant count,
+        which is uniform across scenarios in a two-stage problem
+        (``opt.nonant_length``). Other per-scenario fields (e.g. the xhat
+        circular buffers) have layouts whose multi-source assembly is deferred
+        to later phases; building an overlap map for them raises here rather
+        than silently mis-assembling.
+        """
+        if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
+            k = self.opt.nonant_length
+            return [k] * len(self.opt.all_scenario_names)
+        raise NotImplementedError(
+            f"multi-source assembly of {field} under unequal rank counts is "
+            f"not implemented in the communication-layer cut; only the "
+            f"per-scenario nonant fields (NONANTS_VALS, RELAXED_NONANTS_VALS, "
+            f"DUALS) are supported so far."
+        )
+
+    def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:
+        """Check that one overlap segment fits within the remote buffer it
+        will be read from (the per-segment analogue of _validate_recv_field)."""
+        layout = self.window.strata_buffer_layouts[remote_global_rank]
+        if field not in layout:
+            raise RuntimeError(
+                f"{self.__class__.__name__} on cylinder {self.cylinder_index} "
+                f"expected {field} on global rank {remote_global_rank} but it "
+                f"is not published there."
+            )
+        _, logical_len, _ = layout[field]
+        remote_data_len = logical_len - 1  # exclude the trailing write_id slot
+        # The segment occupies the half-open remote range
+        # [remote_offset, remote_offset + count); the guard is an overrun
+        # check on its exclusive end, so '>' (ending exactly at remote_data_len
+        # is legal) and remote_offset belongs in the LHS (a segment may start
+        # mid-buffer). A reader needing only a subset of a source's scenarios
+        # legitimately ends before remote_data_len, so this is not '!='.
+        if seg.remote_offset + seg.count > remote_data_len:
+            raise RuntimeError(
+                f"{self.__class__.__name__}: overlap segment for {field} reads "
+                f"items [{seg.remote_offset}, {seg.remote_offset + seg.count}) "
+                f"from global rank {remote_global_rank} whose {field} data "
+                f"length is only {remote_data_len}."
+            )
+
+    def _build_overlap_map(self, field: Field, peer_cylinder: int) -> None:
+        """Precompute, for a per-scenario field and a peer cylinder, the list
+        of remote segments (in global-rank terms) that assemble this rank's
+        local buffer, validating each against the remote layout."""
+        base = self._cylinder_bases[peer_cylinder]
+        rc_peer = self.rank_counts[peer_cylinder]
+        # peer cylinder's scenario partition for its own rank count
+        _, peer_slices, _ = self.opt._scenario_tree.scen_names_to_ranks(rc_peer)
+        items_per_scen = self._items_per_scen_for_field(field)
+        segments = compute_overlap_segments(
+            self._local_scen_idxs, peer_slices, items_per_scen
+        )
+        for seg in segments:
+            seg.remote_rank = base + seg.remote_rank  # peer-local -> global
+            self._validate_segment(field, seg.remote_rank, seg)
+        self.overlap_maps[(field, peer_cylinder)] = segments
+        self._overlap_source_ranks[(field, peer_cylinder)] = \
+            sorted({seg.remote_rank for seg in segments})
+
+    def _flex_get_single_source(self, buf, field, peer_cylinder, synchronize):
+        """Read a global/scalar field single-source from a peer cylinder's base
+        rank. Every rank of the cylinder holds the identical value, so reading
+        the base rank is sufficient and keeps the cross-cylinder write_id
+        agreement check (every local rank reads the same remote rank)."""
+        window_rank = self._cylinder_bases[peer_cylinder]
+        if synchronize:
+            self.cylinder_comm.Barrier()
+        last_id = buf.id()
+        self.window.get(buf.window_array(), window_rank, field)
+        new_id = int(buf.array()[-1])
+        if not self._write_ids_agree(new_id, synchronize):
+            buf._is_new = False
+            return False
+        if new_id > last_id:
+            # data is already in buf from the Get above
+            return self._mark_new(buf, new_id)
+        buf._is_new = False
+        return False
+
+    def _flex_get_multi_source(self, buf, field, peer_cylinder, synchronize):
+        """Assemble a per-scenario field from several of a peer cylinder's
+        global ranks using the precomputed overlap map.
+
+        Coherence note. This rank's id is the coherent floor (min) over its
+        sources rather than per-source independent acceptance: a synchronous
+        hub writes all its ranks at one id, so every reader computes the same
+        value and then clears the shared _write_ids_agree check together; a
+        transient mixed-id read floors low, fails agreement, and is retried.
+        (Per-source relaxed acceptance, which would need consumer cooperation,
+        and strict per-field policies such as DUALS are later phases.)
+        """
+        if synchronize:
+            self.cylinder_comm.Barrier()
+        last_id = buf.id()
+
+        # Read each source's whole field once -- data and trailing write_id
+        # from a single atomic snapshot, exactly as the equal-rank reader does.
+        # Reading the data segment and the id in separate Gets would race the
+        # writer: the hub could Put a source between the two reads, yielding
+        # pre-write NaN data paired with a fresh id, which the gate below would
+        # then accept. One whole-field Get per source closes that window. We
+        # also defer writing into buf until the read is accepted, so a rejected
+        # (mixed-id) read never leaves stale data behind.
+        source_snapshots = {}
+        new_id = None
+        for r in self._overlap_source_ranks[(field, peer_cylinder)]:
+            _, logical_len, padded_len = self.window.strata_buffer_layouts[r][field]
+            snapshot = np.empty(padded_len, dtype="d")
+            self.window.get(snapshot, r, field)
+            source_snapshots[r] = snapshot
+            rid = int(snapshot[logical_len - 1])
+            new_id = rid if new_id is None else min(new_id, rid)
+        if new_id is None:
+            new_id = 0
+
+        if not self._write_ids_agree(new_id, synchronize):
+            buf._is_new = False
+            return False
+
+        if new_id > last_id:
+            # assemble the accepted data into buf, then commit via the shared
+            # _mark_new (which stamps the id slot the assembly does not touch)
+            data_view = buf.value_array()
+            for seg in self.overlap_maps[(field, peer_cylinder)]:
+                snapshot = source_snapshots[seg.remote_rank]
+                data_view[seg.local_offset : seg.local_offset + seg.count] = \
+                    snapshot[seg.remote_offset : seg.remote_offset + seg.count]
+            return self._mark_new(buf, new_id)
+        buf._is_new = False
+        return False
 
     def receive_nonant_bounds(self):
         """ receive the bounds on the nonanticipative variables based on

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -52,6 +52,41 @@ _GLOBAL_OR_SCALAR_FIELDS = frozenset((
     Field.EXPECTED_REDUCED_COST,
 ))
 
+# Per-scenario fields that require *strict* coherence when assembled across
+# ranks: every contributing source must be at the same write_id, or the read
+# is rejected and retried. DUALS carries the PH multipliers W_s, whose
+# normalization sum_s p_s W_s = 0 holds only within a single iteration --
+# stitching W from mixed iterations yields an invalid Lagrangian bound. Every
+# other per-scenario field uses *relaxed* coherence (the assembled value may
+# mix iterations; its consumers re-evaluate, so it is always honest).
+_STRICT_COHERENCE_FIELDS = frozenset((
+    Field.DUALS,
+))
+
+
+def reduce_source_write_ids(source_ids, strict: bool) -> int:
+    """Reduce the per-source write_ids of a multi-source read to the single id
+    this rank will compare against its last-accepted id.
+
+    Args:
+        source_ids: write_ids read from each contributing remote rank.
+        strict: if True, the sources must agree on one id (strict coherence);
+            a disagreement returns the sentinel ``-1`` so the read is rejected
+            (it is < any real id, and it breaks the cross-reader agreement
+            check, so every reader rejects together). If False (relaxed), the
+            floor over sources is taken -- a mixed-iteration assembly is
+            accepted, which is fine for fields whose consumers re-evaluate.
+
+    Returns:
+        int: the accepted write_id, or ``-1`` to reject (strict mismatch),
+        or ``0`` when there are no sources.
+    """
+    if not source_ids:
+        return 0
+    if strict:
+        return source_ids[0] if len(set(source_ids)) == 1 else -1
+    return min(source_ids)
+
 def communicator_array(data_length: int):
     """
     Allocate an MPI memory region with a padded length (multiple of 8 doubles = 64B),
@@ -717,13 +752,21 @@ class SPCommunicator:
         """Assemble a per-scenario field from several of a peer cylinder's
         global ranks using the precomputed overlap map.
 
-        Coherence note. This rank's id is the coherent floor (min) over its
-        sources rather than per-source independent acceptance: a synchronous
-        hub writes all its ranks at one id, so every reader computes the same
-        value and then clears the shared _write_ids_agree check together; a
-        transient mixed-id read floors low, fails agreement, and is retried.
-        (Per-source relaxed acceptance, which would need consumer cooperation,
-        and strict per-field policies such as DUALS are later phases.)
+        Coherence note. The per-source write_ids are reduced to this rank's
+        `new_id` by a per-field coherence policy (reduce_source_write_ids):
+
+          * relaxed (default): `new_id` is the floor (min) over sources -- the
+            assembled value may mix iterations, which is fine for fields whose
+            consumers re-evaluate (NONANTS_VALS, ...);
+          * strict (`_STRICT_COHERENCE_FIELDS`, e.g. DUALS): all sources must
+            share one id, else `new_id` is a sentinel (-1) that rejects the
+            read -- a mixed-iteration assembly would be invalid.
+
+        `new_id` then feeds the shared _write_ids_agree check, so the strict
+        rejection is collective-safe: the sentinel (below any real id) simply
+        breaks agreement and every reader rejects together (no early return, no
+        deadlock). With a synchronous hub all sources share an id, so strict
+        reads pass normally and a transient mixed-id read is retried.
         """
         if synchronize:
             self.cylinder_comm.Barrier()
@@ -738,16 +781,17 @@ class SPCommunicator:
         # also defer writing into buf until the read is accepted, so a rejected
         # (mixed-id) read never leaves stale data behind.
         source_snapshots = {}
-        new_id = None
+        source_ids = []
         for r in self._overlap_source_ranks[(field, peer_cylinder)]:
             _, logical_len, padded_len = self.window.strata_buffer_layouts[r][field]
             snapshot = np.empty(padded_len, dtype="d")
             self.window.get(snapshot, r, field)
             source_snapshots[r] = snapshot
-            rid = int(snapshot[logical_len - 1])
-            new_id = rid if new_id is None else min(new_id, rid)
-        if new_id is None:
-            new_id = 0
+            source_ids.append(int(snapshot[logical_len - 1]))
+
+        new_id = reduce_source_write_ids(
+            source_ids, strict=field in _STRICT_COHERENCE_FIELDS
+        )
 
         if not self._write_ids_agree(new_id, synchronize):
             buf._is_new = False

--- a/mpisppy/generic/spokes.py
+++ b/mpisppy/generic/spokes.py
@@ -55,6 +55,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if (cfg.lagrangian_starting_mipgap is not None
                 or cfg.lagrangian_mipgaps_json is not None):
             vanilla.add_gapper(lagrangian_spoke, cfg, "lagrangian")
+        lagrangian_spoke["rank_ratio"] = cfg.lagrangian_rank_ratio
 
     # dual ph spoke
     if cfg.ph_dual:
@@ -140,6 +141,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if cfg.get("stage2_ef_solver_name") is not None:
             xhatshuffle_spoke["opt_kwargs"]["options"]["stage2_ef_solver_name"] = cfg["stage2_ef_solver_name"]
             xhatshuffle_spoke["opt_kwargs"]["options"]["branching_factors"] = cfg["branching_factors"]
+        xhatshuffle_spoke["rank_ratio"] = cfg.xhatshuffle_rank_ratio
 
     if cfg.xhatxbar:
         xhatxbar_spoke = vanilla.xhatxbar_spoke(*beans,
@@ -148,6 +150,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
                                                    all_nodenames=all_nodenames,
                                                    average_scenario_creator=average_scenario_creator,
                                                    feasible_xhat_creator=feasible_xhat_creator)
+        xhatxbar_spoke["rank_ratio"] = cfg.xhatxbar_rank_ratio
 
     # reduced cost fixer options setup
     if cfg.reduced_costs:

--- a/mpisppy/spin_the_wheel.py
+++ b/mpisppy/spin_the_wheel.py
@@ -12,7 +12,7 @@ from mpisppy import haveMPI, global_toc, MPI
 
 from mpisppy.utils import nice_join
 from mpisppy.utils.sputils import first_stage_nonant_writer, scenario_tree_solution_writer
-from mpisppy.utils.rank_apportionment import apportion_ranks
+from mpisppy.utils.rank_apportionment import apportion_ranks, rank_to_cylinder
 
 class WheelSpinner:
 
@@ -104,31 +104,40 @@ class WheelSpinner:
 
         # Create the necessary communicators
         fullcomm = comm_world
+        global_rank = fullcomm.Get_rank()
 
         # Flexible rank assignments: each cylinder may request a rank ratio
-        # relative to the hub (default 1.0) via a "rank_ratio" dict key. The
-        # uniform case (all ratios 1.0) is handled exactly as before. A
-        # non-uniform request is apportioned (largest-remainder, floor of one)
-        # and reported, but building the communicators for unequal per-cylinder
-        # counts is not yet wired into the communicator/window layer.
+        # relative to the hub (default 1.0) via a "rank_ratio" dict key.
+        #
+        # Equal-rank path (all ratios 1.0, today's only case): build
+        # strata_comm and cylinder_comm with the uniform split, exactly as
+        # before.
+        #
+        # Unequal-rank path (any ratio != 1.0): apportion the rank pool into
+        # contiguous global-rank blocks, one per cylinder (largest-remainder,
+        # floor of one). The strata grouping ("rank i of every cylinder") is
+        # undefined when cylinders differ in size, so strata_comm is NOT
+        # created; strata_comm is passed as None and the communicator layer
+        # puts its window on fullcomm and addresses peers by global rank via
+        # overlap maps (Option D in doc/designs/flexible_rank_assignments.md).
+        # The cylinder index plays strata_rank's role (it selects the
+        # spcomm dict and marks the hub as 0).
         rank_ratios = [d.get("rank_ratio", 1.0) for d in communicator_list]
         if any(r != 1.0 for r in rank_ratios):
             rank_counts = apportion_ranks(rank_ratios, fullcomm.Get_size())
             global_toc(
-                f"Requested per-cylinder rank ratios {rank_ratios} -> "
-                f"rank counts {rank_counts}",
-                fullcomm.Get_rank() == 0,
+                f"Flexible rank assignment: ratios {rank_ratios} -> "
+                f"per-cylinder rank counts {rank_counts}",
+                global_rank == 0,
             )
-            raise NotImplementedError(
-                "Per-cylinder rank counts (flexible rank assignments) are not "
-                f"yet wired into the communicator layer; computed allocation "
-                f"{rank_counts}. Run with all rank_ratio == 1.0 for now."
-            )
-
-        strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
-        strata_rank = strata_comm.Get_rank()
-        cylinder_rank = cylinder_comm.Get_rank()
-        global_rank = fullcomm.Get_rank()
+            strata_comm = None
+            cylinder_index, cylinder_rank = rank_to_cylinder(global_rank, rank_counts)
+            cylinder_comm = fullcomm.Split(key=global_rank, color=cylinder_index)
+            strata_rank = cylinder_index
+        else:
+            strata_comm, cylinder_comm = _make_comms(n_spcomms, fullcomm=fullcomm)
+            strata_rank = strata_comm.Get_rank()
+            cylinder_rank = cylinder_comm.Get_rank()
 
         spcomm_dict = communicator_list[strata_rank]
 

--- a/mpisppy/tests/test_flex_coherence_policy.py
+++ b/mpisppy/tests/test_flex_coherence_policy.py
@@ -1,0 +1,56 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unit tests for the per-field coherence policy used by the unequal-rank
+multi-source reader (spcommunicator.reduce_source_write_ids).
+
+The MPI integration tests run against a synchronous PH hub, where all sources
+of a field always carry the same write_id -- so strict and relaxed behave
+identically there and cannot distinguish the policies. These tests pin the
+policy logic directly: strict rejects a mixed-iteration read, relaxed accepts
+the floor."""
+
+import unittest
+
+from mpisppy.cylinders.spcommunicator import reduce_source_write_ids
+
+
+class TestReduceSourceWriteIds(unittest.TestCase):
+
+    def test_relaxed_takes_floor(self):
+        # Relaxed: the assembled value may mix iterations; report the floor so
+        # "new" is detected only once every source has advanced past it.
+        self.assertEqual(reduce_source_write_ids([5, 5, 5], strict=False), 5)
+        self.assertEqual(reduce_source_write_ids([7, 5, 6], strict=False), 5)
+        self.assertEqual(reduce_source_write_ids([3], strict=False), 3)
+
+    def test_strict_accepts_only_when_all_agree(self):
+        # Strict: a single shared id is accepted as-is.
+        self.assertEqual(reduce_source_write_ids([5, 5, 5], strict=True), 5)
+        self.assertEqual(reduce_source_write_ids([9], strict=True), 9)
+
+    def test_strict_rejects_mixed_with_sentinel(self):
+        # Strict: any disagreement -> sentinel -1 (reject). -1 is below any
+        # real write_id, so `new_id > last_id` is false, and it breaks the
+        # cross-reader sum-equality check so every reader rejects together.
+        self.assertEqual(reduce_source_write_ids([5, 4], strict=True), -1)
+        self.assertEqual(reduce_source_write_ids([7, 5, 6], strict=True), -1)
+        self.assertEqual(reduce_source_write_ids([1, 1, 2], strict=True), -1)
+
+    def test_empty_sources_is_zero(self):
+        self.assertEqual(reduce_source_write_ids([], strict=True), 0)
+        self.assertEqual(reduce_source_write_ids([], strict=False), 0)
+
+    def test_sentinel_is_below_any_initial_id(self):
+        # The reject sentinel must be < the initial buffer id (0) so a rejected
+        # strict read is never reported new.
+        self.assertLess(reduce_source_write_ids([2, 3], strict=True), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_cli.py
+++ b/mpisppy/tests/test_flexible_rank_cli.py
@@ -1,0 +1,101 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""The flexible-rank CLI flags (--<spoke>-rank-ratio) are declared with their
+spokes and flow through build_spoke_list onto each spoke dict's rank_ratio key,
+which WheelSpinner reads. Serial; no MPI."""
+
+import unittest
+
+from mpisppy.utils import config
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.generic.spokes import build_spoke_list
+
+
+def _full_cfg():
+    # Declare the same arg set the generic driver does (the subset that
+    # build_spoke_list reads), so every cfg flag it touches exists.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.fwph_args()
+    cfg.lagrangian_args()
+    cfg.gapper_args("lagrangian")
+    cfg.ph_dual_args()
+    cfg.relaxed_ph_args()
+    cfg.ph_xfeas_spoke_args()
+    cfg.subgradient_args()
+    cfg.subgradient_bounder_args()
+    cfg.xhatshuffle_args()
+    cfg.xhatxbar_args()
+    cfg.reduced_costs_args()
+    cfg.sep_rho_args()
+    cfg.coeff_rho_args()
+    cfg.sensi_rho_args()
+    cfg.gradient_args()
+    cfg.gapper_args()
+    return cfg
+
+
+class TestFlexibleRankCLI(unittest.TestCase):
+
+    def test_rank_ratio_args_default_to_one(self):
+        cfg = _full_cfg()
+        self.assertEqual(cfg.lagrangian_rank_ratio, 1.0)
+        self.assertEqual(cfg.xhatshuffle_rank_ratio, 1.0)
+        self.assertEqual(cfg.xhatxbar_rank_ratio, 1.0)
+
+    def test_build_spoke_list_injects_rank_ratio(self):
+        cfg = _full_cfg()
+        cfg.num_scens = 6
+        cfg.lagrangian = True
+        cfg.lagrangian_rank_ratio = 0.5
+        cfg.xhatshuffle = True
+        cfg.xhatshuffle_rank_ratio = 0.25
+        cfg.xhatxbar = True
+        cfg.xhatxbar_rank_ratio = 2.0
+
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(cfg)
+        beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+        spokes = build_spoke_list(
+            cfg, beans, scenario_creator_kwargs,
+            rho_setter=None, all_nodenames=None,
+        )
+
+        # exactly the three enabled spokes, each carrying its requested ratio
+        ratios = sorted(d["rank_ratio"] for d in spokes)
+        self.assertEqual(ratios, sorted([0.5, 0.25, 2.0]))
+        # and every spoke dict got an explicit rank_ratio
+        self.assertTrue(all("rank_ratio" in d for d in spokes))
+
+    def test_default_run_leaves_ratios_at_one(self):
+        # With no ratios set, enabled spokes default to 1.0 (equal-rank path).
+        cfg = _full_cfg()
+        cfg.num_scens = 6
+        cfg.xhatshuffle = True
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(cfg)
+        beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+        spokes = build_spoke_list(
+            cfg, beans, scenario_creator_kwargs,
+            rho_setter=None, all_nodenames=None,
+        )
+        self.assertEqual([d["rank_ratio"] for d in spokes], [1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_cylinders.py
+++ b/mpisppy/tests/test_flexible_rank_cylinders.py
@@ -1,0 +1,139 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end integration test for the unequal-rank communication layer.
+
+Runs farmer with a PH hub and an xhatshuffle spoke at *unequal* rank counts.
+This is the clean Phase-2 case: of the local-sized per-scenario fields, only
+NONANTS_VALS crosses cylinders (hub -> spoke, multi-source assembly). The PH
+hub receives only scalar bounds back from the xhatshuffle spoke, so no DUALS
+(strict coherence) or xhat circular-buffer assembly is involved -- those are
+later phases.
+
+The xhatshuffle spoke reaches a good incumbent only if it reconstructs the
+hub's per-scenario nonant values correctly through the multi-source overlap
+assembly; a misrouted or torn read would feed it garbage candidates. We pin
+correctness two ways, both using fullcomm windows (so neither depends on the
+shared-memory-on-a-split-subcommunicator path, which some MPI builds reject):
+
+  * 4+2 vs 2+4: the same problem solved with the hub larger than the spoke and
+    vice versa. These exercise opposite asymmetry directions -- a spoke rank
+    stitching several hub buffers, and a spoke rank reading a sub-range of one
+    -- yet must reach the same inner bound. (No magic constant.)
+  * both must reach the extensive-form optimum (ground truth) within a loose
+    tolerance.
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_cylinders.py
+"""
+
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+# Extensive-form optimum for farmer with NUM_SCENS=10 (a deterministic LP
+# optimum, solver-independent). Regenerate with mpisppy.opt.ef.ExtensiveForm on
+# one rank if the farmer example ever changes.
+EF_OPT = -122146.70
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    # Fresh cfg/dicts per run: WheelSpinner.run mutates the dicts (key
+    # renaming) and may only run once, so each run needs its own.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.xhatshuffle_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    xhatshuffle_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [xhatshuffle_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    # Bounds are populated on the hub ranks (strata_rank 0); broadcast the
+    # lead hub rank's values so all ranks can assert in lockstep.
+    if wheel.global_rank == 0:
+        payload = (wheel.BestInnerBound, wheel.BestOuterBound)
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankCylinders(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 50
+
+    def test_unequal_rank_both_directions_agree_and_are_optimal(self):
+        # 4-rank hub, 2-rank spoke: each spoke rank stitches NONANTS_VALS from
+        # several hub buffers (multi-segment assembly).
+        ib_42, ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)
+        # 2-rank hub, 4-rank spoke: each spoke rank reads a sub-range of one
+        # hub buffer (the other asymmetry direction).
+        ib_24, ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)
+
+        # Finite incumbents (a torn/garbage read would give inf or error out).
+        self.assertTrue(abs(ib_42) < float("inf"))
+        self.assertTrue(abs(ib_24) < float("inf"))
+
+        # Both asymmetry directions reach the same inner bound.
+        self.assertLess(
+            abs(ib_42 - ib_24), 1e-3 * abs(ib_42),
+            msg=f"4+2 inner bound {ib_42} disagrees with 2+4 {ib_24}",
+        )
+
+        # ...and that bound is the extensive-form optimum (within 1%).
+        for ib in (ib_42, ib_24):
+            self.assertLess(
+                abs(ib - EF_OPT), 1e-2 * abs(EF_OPT),
+                msg=f"inner bound {ib} is not near the EF optimum {EF_OPT}",
+            )
+
+        # Valid bracketing for the (minimizing) farmer objective.
+        self.assertLessEqual(ob_42, ib_42 + 1e-6)
+        self.assertLessEqual(ob_24, ib_24 + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_duals.py
+++ b/mpisppy/tests/test_flexible_rank_duals.py
@@ -1,0 +1,120 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Unequal-rank integration test for the *strict*-coherence path (DUALS).
+
+Runs farmer with a PH hub and a Lagrangian spoke at unequal rank counts. The
+Lagrangian spoke receives DUALS (the PH multipliers W_s) from the hub, which
+crosses cylinders and is assembled multi-source. DUALS uses strict coherence:
+the dual normalization sum_s p_s W_s = 0 holds only within a single PH
+iteration, so a W stitched from mixed iterations would yield an *invalid*
+Lagrangian bound (one that need not lower-bound the optimum).
+
+Correctness is pinned two ways, both on fullcomm windows (environment-safe):
+  * 4+2 vs 2+4 must produce the same Lagrangian outer bound -- the hub's W
+    trajectory is a global reduction independent of the rank split, so the
+    reassembled W (and the bound it yields) must match across both splits; and
+  * the bound must be a valid lower bound on the extensive-form optimum.
+
+A mixed-iteration (non-strict) assembly would break the second property and/or
+make the two splits disagree.
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_duals.py
+"""
+
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+# Extensive-form optimum for farmer NUM_SCENS=10 (see test_flexible_rank_cylinders).
+EF_OPT = -122146.70
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.lagrangian_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.ph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    lagrangian_spoke = vanilla.lagrangian_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    lagrangian_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [lagrangian_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    if wheel.global_rank == 0:
+        payload = wheel.BestOuterBound
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankDuals(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 50
+
+    def test_strict_duals_both_directions_agree_and_bound_valid(self):
+        ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)  # 4-rank hub, 2-rank spoke
+        ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)  # 2-rank hub, 4-rank spoke
+
+        # Finite bound (a broken read would give inf or error out).
+        self.assertTrue(abs(ob_42) < float("inf"))
+        self.assertTrue(abs(ob_24) < float("inf"))
+
+        # The hub's W trajectory is rank-split-independent, so the reassembled
+        # W -- and the Lagrangian bound it yields -- must match across splits.
+        self.assertLess(
+            abs(ob_42 - ob_24), 1e-3 * abs(ob_42),
+            msg=f"4+2 Lagrangian bound {ob_42} disagrees with 2+4 {ob_24}",
+        )
+
+        # A *valid* Lagrangian bound lower-bounds the (minimizing) optimum.
+        # A mixed-iteration W could violate this.
+        self.assertLessEqual(ob_42, EF_OPT + 1e-4 * abs(EF_OPT))
+        self.assertLessEqual(ob_24, EF_OPT + 1e-4 * abs(EF_OPT))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_ratios.py
+++ b/mpisppy/tests/test_flexible_rank_ratios.py
@@ -6,13 +6,23 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""WheelSpinner reads per-cylinder rank_ratio dict keys and, when any is
-non-default, apportions and reports the allocation then raises (the live
-unequal-rank communicator path is not yet wired in). The uniform default
-path is exercised by the cylinder test suite, not here.
+"""WheelSpinner's flexible-rank branch (the equal-vs-unequal decision in
+``run``), exercised without MPI via a stub comm.
 
-WheelSpinner raises before any communicator is built, so a stub comm with
-just Get_size/Get_rank is enough to reach that point without MPI."""
+Phase 1 walled the unequal path off behind a NotImplementedError; the
+communication-layer cut removes that wall and builds per-cylinder
+communicators instead. These tests pin the surviving startup behavior that
+needs no MPI:
+
+  * an infeasible request (more cylinders than ranks) still errors early,
+    from apportion_ranks, before any communicator is built; and
+  * a feasible non-uniform request is no longer rejected -- it proceeds past
+    the (now removed) gate into communicator construction, where the bare
+    stub (which has no Split) fails with something *other* than
+    NotImplementedError.
+
+The full unequal path is exercised end to end by the mpiexec integration
+test; here we only need Get_size/Get_rank to drive the branch decision."""
 
 import unittest
 
@@ -20,7 +30,8 @@ from mpisppy.spin_the_wheel import WheelSpinner
 
 
 class _StubComm:
-    """Minimal comm: WheelSpinner only needs size and rank before it raises."""
+    """Minimal comm: the branch decision only needs size and rank. It has no
+    Split, so reaching communicator construction surfaces as AttributeError."""
     def __init__(self, size, rank=0):
         self._size = size
         self._rank = rank
@@ -33,25 +44,19 @@ class _StubComm:
 
 
 def _min_dict(role, **extra):
-    # Dicts only need the keys WheelSpinner validates before it raises;
+    # Dicts only need the keys WheelSpinner validates before the branch;
     # the classes are never instantiated on this path.
     d = {f"{role}_class": object, "opt_class": object}
     d.update(extra)
     return d
 
 
-class TestFlexibleRankRatios(unittest.TestCase):
-
-    def test_nonuniform_ratio_raises_not_implemented(self):
-        hub = _min_dict("hub", rank_ratio=1.0)
-        spoke = _min_dict("spoke", rank_ratio=0.5)
-        ws = WheelSpinner(hub, [spoke])
-        with self.assertRaises(NotImplementedError):
-            ws.run(comm_world=_StubComm(size=4))
+class TestFlexibleRankBranch(unittest.TestCase):
 
     def test_nonuniform_with_too_few_ranks_raises_value_error(self):
-        # When even the floor-of-one is infeasible, apportion_ranks raises
-        # ValueError first, before the unequal-rank NotImplementedError.
+        # Two 0.5-ratio spokes + a hub is three cylinders; with only two ranks
+        # the floor-of-one is infeasible, so apportion_ranks raises ValueError
+        # before any communicator construction is attempted.
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke_a = _min_dict("spoke", rank_ratio=0.5)
         spoke_b = _min_dict("spoke", rank_ratio=0.5)
@@ -59,16 +64,30 @@ class TestFlexibleRankRatios(unittest.TestCase):
         with self.assertRaises(ValueError):
             ws.run(comm_world=_StubComm(size=2))
 
-    def test_explicit_uniform_ratios_proceed(self):
-        # All ratios 1.0 -> no unequal-rank raise; the next step (_make_comms)
-        # is reached and fails on the stub (no Split). Reaching that point at
-        # all proves WheelSpinner did not raise NotImplementedError.
+    def test_nonuniform_no_longer_raises_not_implemented(self):
+        # A feasible non-uniform request used to raise NotImplementedError.
+        # Now it proceeds to build communicators; on the bare stub (no Split)
+        # that surfaces as some other exception -- proving the gate is gone.
+        hub = _min_dict("hub", rank_ratio=1.0)
+        spoke = _min_dict("spoke", rank_ratio=0.5)
+        ws = WheelSpinner(hub, [spoke])
+        # Reaching communicator construction (past the removed gate) fails on
+        # the stub's missing Split with AttributeError, not NotImplementedError.
+        with self.assertRaises(AttributeError):
+            ws.run(comm_world=_StubComm(size=4))
+
+    def test_uniform_ratios_use_equal_path(self):
+        # All ratios 1.0 -> equal path; reaches _make_comms and fails on the
+        # stub (no Split). Reaching that point at all confirms the unequal
+        # branch was not taken and nothing raised NotImplementedError.
         hub = _min_dict("hub", rank_ratio=1.0)
         spoke = _min_dict("spoke", rank_ratio=1.0)
         ws = WheelSpinner(hub, [spoke])
-        with self.assertRaises(Exception) as ctx:
+        # Equal path reaches _make_comms and fails on the stub's missing Split
+        # with AttributeError; reaching it confirms the unequal branch was not
+        # taken and nothing raised NotImplementedError.
+        with self.assertRaises(AttributeError):
             ws.run(comm_world=_StubComm(size=2))
-        self.assertNotIsInstance(ctx.exception, NotImplementedError)
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_rank_apportionment.py
+++ b/mpisppy/tests/test_rank_apportionment.py
@@ -6,11 +6,16 @@
 # All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
 # full copyright and license information.
 ###############################################################################
-"""Unit tests for mpisppy.utils.rank_apportionment.apportion_ranks."""
+"""Unit tests for mpisppy.utils.rank_apportionment: apportion_ranks plus the
+contiguous-block layout helpers cylinder_bases and rank_to_cylinder."""
 
 import unittest
 
-from mpisppy.utils.rank_apportionment import apportion_ranks
+from mpisppy.utils.rank_apportionment import (
+    apportion_ranks,
+    cylinder_bases,
+    rank_to_cylinder,
+)
 
 
 class TestApportionRanks(unittest.TestCase):
@@ -104,6 +109,49 @@ class TestApportionRanks(unittest.TestCase):
         a = apportion_ranks([1.0, 0.5, 0.25], 14)
         b = apportion_ranks([0.25, 0.5, 1.0], 14)
         self.assertEqual(a, list(reversed(b)))
+
+
+class TestContiguousBlockLayout(unittest.TestCase):
+    """cylinder_bases / rank_to_cylinder define the contiguous global-rank
+    block layout used by the unequal-rank path."""
+
+    def test_bases_doc_example(self):
+        # 8 / 4 / 2 -> blocks start at 0, 8, 12.
+        self.assertEqual(cylinder_bases([8, 4, 2]), [0, 8, 12])
+
+    def test_bases_single_cylinder(self):
+        self.assertEqual(cylinder_bases([5]), [0])
+
+    def test_rank_to_cylinder_doc_example(self):
+        counts = [8, 4, 2]
+        # hub block 0..7
+        self.assertEqual(rank_to_cylinder(0, counts), (0, 0))
+        self.assertEqual(rank_to_cylinder(7, counts), (0, 7))
+        # lagrangian block 8..11
+        self.assertEqual(rank_to_cylinder(8, counts), (1, 0))
+        self.assertEqual(rank_to_cylinder(11, counts), (1, 3))
+        # xhat block 12..13
+        self.assertEqual(rank_to_cylinder(12, counts), (2, 0))
+        self.assertEqual(rank_to_cylinder(13, counts), (2, 1))
+
+    def test_rank_to_cylinder_covers_every_rank(self):
+        # Every global rank maps to exactly one (cylinder, local rank), and
+        # the local ranks within a cylinder are 0..count-1 in order.
+        counts = [3, 1, 2, 4]
+        bases = cylinder_bases(counts)
+        seen = {c: [] for c in range(len(counts))}
+        for gr in range(sum(counts)):
+            cyl, local = rank_to_cylinder(gr, counts)
+            self.assertEqual(gr, bases[cyl] + local)
+            seen[cyl].append(local)
+        for cyl, count in enumerate(counts):
+            self.assertEqual(seen[cyl], list(range(count)))
+
+    def test_rank_to_cylinder_out_of_range_raises(self):
+        with self.assertRaises(ValueError):
+            rank_to_cylinder(14, [8, 4, 2])
+        with self.assertRaises(ValueError):
+            rank_to_cylinder(-1, [8, 4, 2])
 
 
 if __name__ == "__main__":

--- a/mpisppy/tests/test_spwindow_multisource.py
+++ b/mpisppy/tests/test_spwindow_multisource.py
@@ -1,0 +1,137 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Low-level multi-source RMA assembly test for the unequal-rank path.
+
+This exercises the dangerous part of the communication-layer cut -- real
+passive-target one-sided RMA reads assembled from several remote ranks via
+an overlap map -- in isolation from the hub/spoke stack. It builds an
+``SPWindow`` directly on ``COMM_WORLD``, has a "writer" cylinder publish
+known per-scenario values, and has a smaller "reader" cylinder reconstruct
+its own scenarios' values with ``compute_overlap_segments`` + partial
+``SPWindow.get`` reads. A reader rank whose scenarios straddle a writer-rank
+boundary must stitch the result from two writer buffers; that is the case the
+plain single-source reader cannot handle and the multi-source path must.
+
+Run with: ``mpiexec -np 6 python -m mpi4py -m pytest <thisfile>`` (or via the
+straight_tests / coverage harness, which launches mpiexec for it).
+"""
+
+import unittest
+
+import numpy as np
+
+from mpisppy import MPI
+from mpisppy.cylinders.spwindow import Field, SPWindow, padded_len_n_doubles
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+
+fullcomm = MPI.COMM_WORLD
+global_rank = fullcomm.Get_rank()
+global_size = fullcomm.Get_size()
+
+
+def _contiguous_slices(n_scen, n_proc):
+    """Contiguous per-rank scenario partition, matching the formula used by
+    sputils._ScenTree.scen_names_to_ranks (rank -> list of global scen idxs)."""
+    avg = n_scen / n_proc
+    return [list(range(int(i * avg), int((i + 1) * avg))) for i in range(n_proc)]
+
+
+def _scen_value(scen, item):
+    """A distinct, recognizable value for (global scenario, item) so a
+    misrouted read is caught rather than silently plausible."""
+    return 1000.0 * scen + item
+
+
+@unittest.skipUnless(global_size == 6, "needs exactly 6 MPI ranks (4 writers + 2 readers)")
+class TestMultiSourceAssembly(unittest.TestCase):
+    """Ranks 0-3 are a 4-rank writer cylinder; ranks 4-5 a 2-rank reader
+    cylinder. Both cover the same N_SCEN scenarios, split differently, so a
+    reader rank reads from several writer ranks."""
+
+    N_SCEN = 10
+    WRITER_RANKS = 4   # global ranks 0..3
+    READER_RANKS = 2   # global ranks 4..5
+
+    def _run_one(self, items_per_scen_k):
+        writer_slices = _contiguous_slices(self.N_SCEN, self.WRITER_RANKS)
+        reader_slices = _contiguous_slices(self.N_SCEN, self.READER_RANKS)
+        k = items_per_scen_k
+
+        is_writer = global_rank < self.WRITER_RANKS
+
+        # Every rank builds the (collective) window. Writers publish a
+        # NONANTS_VALS-like field sized to their local scenarios; readers
+        # publish nothing and only read.
+        if is_writer:
+            my_scen = writer_slices[global_rank]
+            data_len = k * len(my_scen)
+            # Mirror the production layout: every field reserves a trailing
+            # write_id slot. The overlap segments below address only the data
+            # region [0, data_len), so this also guards that assembly never
+            # reads into the id slot.
+            logical_len = data_len + 1
+            padded = padded_len_n_doubles(logical_len)
+            my_fields = {Field.NONANTS_VALS: (logical_len, padded)}
+        else:
+            my_fields = {}
+
+        win = SPWindow(my_fields, fullcomm)
+
+        if is_writer:
+            padded = win.buffer_layout[Field.NONANTS_VALS][2]
+            buf = np.full(padded, np.nan, dtype="d")
+            for i, scen in enumerate(my_scen):
+                for j in range(k):
+                    buf[i * k + j] = _scen_value(scen, j)
+            win.put(buf, Field.NONANTS_VALS)
+
+        # Ensure all writer puts are visible before any reader get.
+        fullcomm.Barrier()
+
+        if not is_writer:
+            reader_local = global_rank - self.WRITER_RANKS
+            my_scen = reader_slices[reader_local]
+            segments = compute_overlap_segments(
+                my_scen, writer_slices, [k] * self.N_SCEN
+            )
+            # writer cylinder's global-rank base is 0
+            local_buf = np.full(k * len(my_scen), np.nan, dtype="d")
+            for seg in segments:
+                dest = local_buf[seg.local_offset : seg.local_offset + seg.count]
+                win.get(dest, seg.remote_rank, Field.NONANTS_VALS,
+                        item_offset=seg.remote_offset, item_count=seg.count)
+
+            expected = np.array(
+                [_scen_value(scen, j) for scen in my_scen for j in range(k)],
+                dtype="d",
+            )
+            np.testing.assert_array_equal(
+                local_buf, expected,
+                err_msg=f"{global_rank=} {k=} {my_scen=} {segments=}",
+            )
+            # A straddling reader rank must have used more than one segment.
+            if reader_local == 0:
+                self.assertGreater(
+                    len(segments), 1,
+                    "reader rank 0 spans a writer-rank boundary; expected a "
+                    "multi-segment assembly",
+                )
+
+        fullcomm.Barrier()
+        win.free()
+
+    def test_assembly_one_item_per_scenario(self):
+        self._run_one(items_per_scen_k=1)
+
+    def test_assembly_multi_item_per_scenario(self):
+        self._run_one(items_per_scen_k=3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -745,6 +745,13 @@ class Config(pyofig.ConfigDict):
                               domain=bool,
                               default=False)
 
+        self.add_to_config('lagrangian_rank_ratio',
+                              description="MPI ranks for the lagrangian spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
+
         self.add_solver_specs("lagrangian")
         self.add_mipgap_specs("lagrangian")
 
@@ -971,6 +978,13 @@ class Config(pyofig.ConfigDict):
                            domain=bool,
                            default=False)
 
+        self.add_to_config('xhatshuffle_rank_ratio',
+                           description="MPI ranks for the xhatshuffle spoke "
+                                       "relative to the hub (flexible rank "
+                                       "assignments; default 1.0 = equal)",
+                           domain=float,
+                           default=1.0)
+
         self.add_to_config('add_reversed_shuffle',
                            description="using also the reversed shuffling (multistage only, default True)",
                            domain=bool,
@@ -1069,6 +1083,13 @@ class Config(pyofig.ConfigDict):
                               description="have an xhatxbar spoke",
                               domain=bool,
                               default=False)
+
+        self.add_to_config('xhatxbar_rank_ratio',
+                              description="MPI ranks for the xhatxbar spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
 
         self.add_to_config('xhatxbar_try_jensens_first',
                            description="before entering the xhatxbar main loop, solve "

--- a/mpisppy/utils/rank_apportionment.py
+++ b/mpisppy/utils/rank_apportionment.py
@@ -82,3 +82,50 @@ def apportion_ranks(ratios, n_proc):
         counts[zeros[0]] += 1
 
     return counts
+
+
+def cylinder_bases(rank_counts):
+    """First global rank of each cylinder's contiguous block.
+
+    The unequal-rank path lays cylinders out as contiguous global-rank
+    blocks in declaration order: cylinder ``i`` owns global ranks
+    ``[bases[i], bases[i] + rank_counts[i])``.
+
+    Args:
+        rank_counts: per-cylinder rank counts (e.g. from ``apportion_ranks``).
+
+    Returns:
+        list[int]: ``bases[i]`` is the lowest global rank in cylinder ``i``.
+    """
+    bases = []
+    base = 0
+    for rc in rank_counts:
+        bases.append(base)
+        base += rc
+    return bases
+
+
+def rank_to_cylinder(global_rank, rank_counts):
+    """Locate a global rank within the contiguous-block cylinder layout.
+
+    Args:
+        global_rank: a rank in ``[0, sum(rank_counts))``.
+        rank_counts: per-cylinder rank counts (e.g. from ``apportion_ranks``).
+
+    Returns:
+        tuple[int, int]: ``(cylinder_index, rank_within_cylinder)``, where
+        ``rank_within_cylinder`` is this rank's position in its cylinder's
+        ``cylinder_comm`` (i.e. its ``cylinder_rank``).
+
+    Raises:
+        ValueError: if ``global_rank`` is outside the apportioned range.
+    """
+    base = 0
+    for cyl, rc in enumerate(rank_counts):
+        if base <= global_rank < base + rc:
+            return cyl, global_rank - base
+        base += rc
+    raise ValueError(
+        f"rank_to_cylinder: global_rank {global_rank} is outside the "
+        f"apportioned range [0, {base}) for rank_counts {list(rank_counts)}"
+    )

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -143,6 +143,9 @@ run_phase "test_flexible_rank_ratios (serial)" \
 run_phase "test_flex_coherence_policy (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flex_coherence_policy.py -v
 
+run_phase "test_flexible_rank_cli (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_cli.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -140,6 +140,9 @@ run_phase "test_spwindow_partial_get (serial)" \
 run_phase "test_flexible_rank_ratios (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_ratios.py -v
 
+run_phase "test_flex_coherence_policy (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flex_coherence_policy.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 
@@ -189,6 +192,9 @@ run_phase "test_spwindow_multisource (mpiexec -np 6)" \
 
 run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
     mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
+
+run_phase "test_flexible_rank_duals (mpiexec -np 6)" \
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_duals.py
 
 # ---------- Tests that spawn mpiexec internally ----------
 

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -53,6 +53,13 @@ has_module() {
     python -c "import $1" 2>/dev/null
 }
 
+# -oversubscribe is OpenMPI-only (MPICH rejects it). Some flexible-rank tests
+# need more ranks than the host has cores, so add the flag only under OpenMPI.
+OVERSUBSCRIBE=""
+if mpiexec --version 2>&1 | grep -qiE "open[ -]?mpi|open ?rte"; then
+    OVERSUBSCRIBE="-oversubscribe"
+fi
+
 # ---------- Serial pytest / unittest tests ----------
 
 run_phase "test_ef_ph (serial)" \
@@ -173,6 +180,15 @@ run_phase "test_dualcg_main (serial)" \
 
 run_phase "test_dualcg_with_cylinders (mpiexec -np 2)" \
     mpiexec -np 2 coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_dualcg_with_cylinders.py
+
+# Flexible (unequal) rank assignments: both need 6 ranks (4-rank + 2-rank
+# cylinders); $OVERSUBSCRIBE (set above, OpenMPI only) lets them run on hosts
+# with fewer than 6 cores.
+run_phase "test_spwindow_multisource (mpiexec -np 6)" \
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_spwindow_multisource.py
+
+run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
+    mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_cylinders.py
 
 # ---------- Tests that spawn mpiexec internally ----------
 


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Pyomo/mpi-sppy#731 — Phase 2: communication layer** — ✅ merged
> 3. **Pyomo/mpi-sppy#736 — Phase 3a: per-field coherence (DUALS strict)** (targets `main`)
> 4. **DLWoodruff/mpi-sppy-1#14 — Phase 3b: CLI rank-ratio flags** (targets `flex-ranks-phase3-coherence`) ← _this PR_
> 5. **DLWoodruff/mpi-sppy-1#15 — Phase 4a: two-stage xhat fields** (targets `flex-ranks-phase3b-cli`)
>
> 6. **DLWoodruff/mpi-sppy-1#16 — Phase 4b: multistage per-node xhat sourcing** (targets `flex-ranks-phase4a-xhat-2stage`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

Makes flexible ranks usable from the `generic_cylinders` command line, for the
spokes verified to work under unequal ranks.

## What's here

- **CLI flags** (`config.py`): `--lagrangian-rank-ratio` (DUALS, strict),
  `--xhatshuffle-rank-ratio` and `--xhatxbar-rank-ratio` (NONANTS_VALS,
  relaxed), each a float defaulting to `1.0` (equal), declared with its spoke.
  Spokes whose crossed fields aren't flex-supported yet (fwph, ph_xfeas, …)
  intentionally get **no** flag.
- **Injection** (`generic/spokes.py`): `build_spoke_list` sets each spoke
  dict's `rank_ratio` from its cfg value (what `WheelSpinner` reads).
- **Guard / defense in depth** (`spcommunicator.py`): the
  `_items_per_scen_for_field` error now names the spoke and is actionable, e.g.
  *"FWPHHub reads RECENT_XHATS, whose multi-source assembly … is not supported
  yet … run at rank_ratio == 1.0, or wait for the phase that adds RECENT_XHATS
  support."* It fires at **window creation** (startup), before solving, for any
  unsupported per-scenario field reached via any path (CLI, callback, or a
  hand-built dict) — so the not-yet-exposed spokes are protected too.

## Tests

- **`test_flexible_rank_cli.py`** (serial): ratio args default to 1.0;
  `build_spoke_list` injects the requested ratios; a default run stays at 1.0.

Wired into `run_coverage.bash` + the CI serial suite. `test_config.py` (85)
unaffected by the new args.

## Out of scope

- **cross_scen** multi-source — non-functional + untested upstream
  (Pyomo/mpi-sppy#728, sizing Pyomo/mpi-sppy#727); excluded from the flex stack.
- **BEST_XHAT / RECENT_XHATS** first-stage sourcing, **multistage**, and
  **FWPH** — Phase 4. Flags for those spokes arrive when their fields land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





