### PR TITLE
flex-ranks phase 4a: two-stage xhat fields (BEST_XHAT/RECENT_XHATS/XFEAS)

### DIFF
--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -978,6 +978,7 @@ jobs:
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_spwindow_multisource.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_cylinders.py
           mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_duals.py
+          mpiexec -np 6 coverage run $COV_ARGS -m mpi4py test_flexible_rank_xhat.py
 
       - name: Upload coverage data
         if: always()
@@ -1141,7 +1142,8 @@ jobs:
             mpisppy/tests/test_spwindow_partial_get.py \
             mpisppy/tests/test_flexible_rank_ratios.py \
             mpisppy/tests/test_flex_coherence_policy.py \
-            mpisppy/tests/test_flexible_rank_cli.py
+            mpisppy/tests/test_flexible_rank_cli.py \
+            mpisppy/tests/test_flex_xhat_assembly.py
 
       - name: Upload coverage data
         if: always()

--- a/.github/workflows/test_pr_and_main.yml
+++ b/.github/workflows/test_pr_and_main.yml
@@ -1140,7 +1140,8 @@ jobs:
             mpisppy/tests/test_overlap_map.py \
             mpisppy/tests/test_spwindow_partial_get.py \
             mpisppy/tests/test_flexible_rank_ratios.py \
-            mpisppy/tests/test_flex_coherence_policy.py
+            mpisppy/tests/test_flex_coherence_policy.py \
+            mpisppy/tests/test_flexible_rank_cli.py
 
       - name: Upload coverage data
         if: always()

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -27,7 +27,7 @@ from math import inf
 
 from mpisppy import MPI, global_toc
 from mpisppy.cylinders.spwindow import Field, FieldLengths, SPWindow, padded_len_n_doubles
-from mpisppy.cylinders.overlap_map import compute_overlap_segments
+from mpisppy.cylinders.overlap_map import OverlapSegment, compute_overlap_segments
 from mpisppy.utils.rank_apportionment import (
     apportion_ranks,
     cylinder_bases,
@@ -61,6 +61,22 @@ _GLOBAL_OR_SCALAR_FIELDS = frozenset((
 # mix iterations; its consumers re-evaluate, so it is always honest).
 _STRICT_COHERENCE_FIELDS = frozenset((
     Field.DUALS,
+))
+
+# Category-2 xhat fields: per-scenario layout [first-stage nonants, cost] whose
+# nonant portion is an incumbent first-stage decision identical across all
+# scenarios by non-anticipativity (the candidate fixes the first stage when it
+# is evaluated). Multi-source assembly fills each scenario's block from the rank
+# that holds it; if those ranks sit at different write_ids the first-stage
+# values could end up inconsistent across scenarios. After assembly we restore
+# NAC by overwriting every scenario's first-stage portion with a single coherent
+# reference (see _enforce_first_stage_nac). The per-scenario cost slot is left
+# alone -- it is genuinely per-scenario (Category 1). XFEAS is *not* here: it
+# carries per-scenario *distinct* iterates (its consumer tries each scenario's x
+# as its own candidate), so it is assembled per-scenario with no NAC fix-up.
+_FIRST_STAGE_NAC_FIELDS = frozenset((
+    Field.BEST_XHAT,
+    Field.RECENT_XHATS,
 ))
 
 
@@ -668,14 +684,29 @@ class SPCommunicator:
 
         For the nonant-valued fields this is the per-scenario nonant count,
         which is uniform across scenarios in a two-stage problem
-        (``opt.nonant_length``). Other per-scenario fields (e.g. the xhat
-        circular buffers) have layouts whose multi-source assembly is deferred
-        to later phases; building an overlap map for them raises here rather
-        than silently mis-assembling.
+        (``opt.nonant_length``). For the xhat fields each scenario contributes a
+        ``[nonants, cost]`` block, so the count is ``nonant_length + 1``; the
+        circular ``RECENT_XHATS`` returns the same single-version block size and
+        is expanded across versions in ``_build_overlap_map``.
         """
         if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
             k = self.opt.nonant_length
             return [k] * len(self.opt.all_scenario_names)
+        if field in (Field.BEST_XHAT, Field.RECENT_XHATS, Field.XFEAS):
+            # Each scenario's block is [first-stage nonants, per-scenario cost].
+            # Two-stage only: under multistage the NAC-redundant portion is
+            # per-tree-node (not one global first stage), so the cost-vs-nonant
+            # split and the NAC fix-up need per-node sourcing -- a later phase.
+            if self.opt.multistage:
+                raise NotImplementedError(
+                    f"Flexible (unequal) rank assignments: {self.__class__.__name__} "
+                    f"reads {field.name} on a multistage problem, whose per-node "
+                    f"first-stage sourcing is not implemented yet (two-stage is). "
+                    f"Run the cylinders that exchange {field.name} at equal rank "
+                    f"counts (rank_ratio == 1.0), or wait for the multistage phase."
+                )
+            k = self.opt.nonant_length
+            return [k + 1] * len(self.opt.all_scenario_names)
         # Reached at startup (window creation), not mid-solve: this cylinder is
         # in a flexible-rank run and reads a per-scenario field whose
         # multi-source assembly across unequal rank counts is not implemented
@@ -683,11 +714,9 @@ class SPCommunicator:
         raise NotImplementedError(
             f"Flexible (unequal) rank assignments: {self.__class__.__name__} "
             f"reads {field.name}, whose multi-source assembly across cylinders "
-            f"with different rank counts is not supported yet (only "
-            f"{Field.NONANTS_VALS.name}, {Field.RELAXED_NONANTS_VALS.name}, and "
-            f"{Field.DUALS.name} are). Run the cylinders that exchange "
-            f"{field.name} at equal rank counts (rank_ratio == 1.0), or wait "
-            f"for the phase that adds {field.name} support."
+            f"with different rank counts is not supported yet. Run the cylinders "
+            f"that exchange {field.name} at equal rank counts (rank_ratio == 1.0), "
+            f"or wait for the phase that adds {field.name} support."
         )
 
     def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:
@@ -730,10 +759,78 @@ class SPCommunicator:
         )
         for seg in segments:
             seg.remote_rank = base + seg.remote_rank  # peer-local -> global
+        if field == Field.RECENT_XHATS:
+            # The single-version segments computed above describe one xhat
+            # version's per-scenario layout; replicate them across all versions
+            # of the circular buffer (see _expand_to_circular_versions).
+            segments = self._expand_to_circular_versions(
+                segments, peer_slices, base, items_per_scen
+            )
+        for seg in segments:
             self._validate_segment(field, seg.remote_rank, seg)
         self.overlap_maps[(field, peer_cylinder)] = segments
         self._overlap_source_ranks[(field, peer_cylinder)] = \
             sorted({seg.remote_rank for seg in segments})
+
+    def _expand_to_circular_versions(self, base_segments, peer_slices, base,
+                                     items_per_scen):
+        """Replicate single-version overlap segments across the versions of the
+        ``RECENT_XHATS`` circular buffer.
+
+        ``RECENT_XHATS`` holds ``V`` versions, each a ``BEST_XHAT``-sized block
+        laid out per scenario. Within one version the per-scenario blocks are
+        contiguous, but version ``v``'s block for a given rank sits at
+        ``v * (that rank's version size)`` -- and the version size differs per
+        rank because it scales with the rank's local scenario count. So a
+        single-version segment is emitted once per version, shifting its remote
+        offset by the *source rank's* version size and its local offset by this
+        rank's version size. Reading every physical slot faithfully (just
+        re-partitioned across scenarios) lets the receiver's ``RecvCircularBuffer``
+        interpret the write_id exactly as on the equal-rank path.
+        """
+        nversions = (self._field_lengths[Field.RECENT_XHATS]
+                     // self._field_lengths[Field.BEST_XHAT])
+        local_version_size = self._field_lengths[Field.BEST_XHAT]
+        # global source rank -> its single-version (BEST_XHAT) block size, in items
+        remote_version_size = {
+            base + r: sum(items_per_scen[s] for s in scens)
+            for r, scens in enumerate(peer_slices)
+        }
+        expanded = []
+        for v in range(nversions):
+            for seg in base_segments:
+                expanded.append(OverlapSegment(
+                    remote_rank=seg.remote_rank,
+                    remote_offset=v * remote_version_size[seg.remote_rank] + seg.remote_offset,
+                    local_offset=v * local_version_size + seg.local_offset,
+                    count=seg.count,
+                ))
+        return expanded
+
+    def _enforce_first_stage_nac(self, data_view, field):
+        """Restore non-anticipativity of the first-stage portion of a Category-2
+        xhat field after multi-source assembly (two-stage case).
+
+        Each per-scenario block is ``[first-stage nonants, cost]``. The nonant
+        portion is identical across scenarios by construction, but the blocks
+        were assembled from possibly different ranks/write_ids, so overwrite
+        every scenario's nonants with a single coherent reference -- the first
+        scenario's, which came whole from one rank. The cost slots are left
+        untouched (genuinely per-scenario). For ``RECENT_XHATS`` this is applied
+        independently within each version block. Two-stage only; multistage
+        per-node sourcing is guarded in _items_per_scen_for_field.
+        """
+        k = self.opt.nonant_length            # first-stage nonants per scenario
+        block = k + 1                          # [nonants, cost]
+        nscen = len(self._local_scen_idxs)
+        version_size = nscen * block
+        nversions = len(data_view) // version_size  # 1 for BEST_XHAT, V for RECENT_XHATS
+        for v in range(nversions):
+            v0 = v * version_size
+            ref = data_view[v0:v0 + k].copy()  # this version's scenario-0 first stage
+            for i in range(1, nscen):
+                off = v0 + i * block
+                data_view[off:off + k] = ref
 
     def _flex_get_single_source(self, buf, field, peer_cylinder, synchronize):
         """Read a global/scalar field single-source from a peer cylinder's base
@@ -774,6 +871,11 @@ class SPCommunicator:
         breaks agreement and every reader rejects together (no early return, no
         deadlock). With a synchronous hub all sources share an id, so strict
         reads pass normally and a transient mixed-id read is retried.
+
+        For the Category-2 xhat fields (`_FIRST_STAGE_NAC_FIELDS`) the assembled
+        per-scenario blocks then pass through _enforce_first_stage_nac, which
+        restores the non-anticipativity of their first-stage portion (the cost
+        portion stays per-scenario).
         """
         if synchronize:
             self.cylinder_comm.Barrier()
@@ -812,6 +914,8 @@ class SPCommunicator:
                 snapshot = source_snapshots[seg.remote_rank]
                 data_view[seg.local_offset : seg.local_offset + seg.count] = \
                     snapshot[seg.remote_offset : seg.remote_offset + seg.count]
+            if field in _FIRST_STAGE_NAC_FIELDS:
+                self._enforce_first_stage_nac(data_view, field)
             return self._mark_new(buf, new_id)
         buf._is_new = False
         return False

--- a/mpisppy/cylinders/spcommunicator.py
+++ b/mpisppy/cylinders/spcommunicator.py
@@ -676,11 +676,18 @@ class SPCommunicator:
         if field in (Field.NONANTS_VALS, Field.RELAXED_NONANTS_VALS, Field.DUALS):
             k = self.opt.nonant_length
             return [k] * len(self.opt.all_scenario_names)
+        # Reached at startup (window creation), not mid-solve: this cylinder is
+        # in a flexible-rank run and reads a per-scenario field whose
+        # multi-source assembly across unequal rank counts is not implemented
+        # yet. Fail here with an actionable message rather than mis-assembling.
         raise NotImplementedError(
-            f"multi-source assembly of {field} under unequal rank counts is "
-            f"not implemented in the communication-layer cut; only the "
-            f"per-scenario nonant fields (NONANTS_VALS, RELAXED_NONANTS_VALS, "
-            f"DUALS) are supported so far."
+            f"Flexible (unequal) rank assignments: {self.__class__.__name__} "
+            f"reads {field.name}, whose multi-source assembly across cylinders "
+            f"with different rank counts is not supported yet (only "
+            f"{Field.NONANTS_VALS.name}, {Field.RELAXED_NONANTS_VALS.name}, and "
+            f"{Field.DUALS.name} are). Run the cylinders that exchange "
+            f"{field.name} at equal rank counts (rank_ratio == 1.0), or wait "
+            f"for the phase that adds {field.name} support."
         )
 
     def _validate_segment(self, field: Field, remote_global_rank: int, seg) -> None:

--- a/mpisppy/generic/spokes.py
+++ b/mpisppy/generic/spokes.py
@@ -55,6 +55,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if (cfg.lagrangian_starting_mipgap is not None
                 or cfg.lagrangian_mipgaps_json is not None):
             vanilla.add_gapper(lagrangian_spoke, cfg, "lagrangian")
+        lagrangian_spoke["rank_ratio"] = cfg.lagrangian_rank_ratio
 
     # dual ph spoke
     if cfg.ph_dual:
@@ -140,6 +141,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
         if cfg.get("stage2_ef_solver_name") is not None:
             xhatshuffle_spoke["opt_kwargs"]["options"]["stage2_ef_solver_name"] = cfg["stage2_ef_solver_name"]
             xhatshuffle_spoke["opt_kwargs"]["options"]["branching_factors"] = cfg["branching_factors"]
+        xhatshuffle_spoke["rank_ratio"] = cfg.xhatshuffle_rank_ratio
 
     if cfg.xhatxbar:
         xhatxbar_spoke = vanilla.xhatxbar_spoke(*beans,
@@ -148,6 +150,7 @@ def build_spoke_list(cfg, beans, scenario_creator_kwargs,
                                                    all_nodenames=all_nodenames,
                                                    average_scenario_creator=average_scenario_creator,
                                                    feasible_xhat_creator=feasible_xhat_creator)
+        xhatxbar_spoke["rank_ratio"] = cfg.xhatxbar_rank_ratio
 
     # reduced cost fixer options setup
     if cfg.reduced_costs:

--- a/mpisppy/tests/test_flex_xhat_assembly.py
+++ b/mpisppy/tests/test_flex_xhat_assembly.py
@@ -1,0 +1,220 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""Serial, exact-value tests for the Phase-4a xhat-field assembly math.
+
+The np=6 integration test (test_flexible_rank_xhat) confirms the end-to-end
+FWPH run converges at unequal ranks, but a synchronous hub keeps every source at
+the same write_id, so it cannot distinguish a correct first-stage NAC fix-up
+from no fix-up at all, nor pin the exact byte layout of the version-interleaved
+circular buffer. These tests do, directly and without MPI, by exercising the
+two pieces of new arithmetic against a hand-checked straddle layout:
+
+  * ``_expand_to_circular_versions`` -- replicating one version's overlap
+    segments across the circular buffer, with a *different* version stride per
+    source rank (the peer ranks here hold unequal scenario counts);
+  * ``_enforce_first_stage_nac`` -- overwriting every scenario's first-stage
+    portion with the first scenario's, per version, leaving the per-scenario
+    cost slots alone.
+
+To force the fix-up to do visible work, the two source ranks publish *different*
+first-stage values (as if read at mixed write_ids); a correct fix-up collapses
+them to a single coherent vector, an absent one would leave them split. XFEAS,
+which carries per-scenario *distinct* iterates, must NOT be collapsed.
+
+The methods read only a handful of attributes, so a tiny stand-in object stands
+in for a fully-constructed SPCommunicator.
+"""
+
+import types
+import unittest
+
+import numpy as np
+
+from mpisppy.cylinders.spwindow import Field
+from mpisppy.cylinders.spcommunicator import SPCommunicator
+from mpisppy.cylinders.overlap_map import compute_overlap_segments
+
+
+# --- fixed straddle layout shared by the tests ---------------------------
+#
+# 6 scenarios (global indices 0..5), 2 first-stage nonants each (K=2), so every
+# per-scenario block is [n, n, cost] (length 3).
+#
+# Peer (source) cylinder: 2 ranks holding *unequal* counts --
+#   rank 0 -> scenarios [0,1,2,3]   (4 scenarios; version stride 4*3 = 12)
+#   rank 1 -> scenarios [4,5]       (2 scenarios; version stride 2*3 =  6)
+# The unequal strides are the point: a single version stride would mis-assemble
+# the later versions of one of the ranks.
+#
+# Receiver (local) rank holds scenarios [2,3,4,5] -- straddling both source
+# ranks (2,3 from rank 0; 4,5 from rank 1).
+K = 2
+BLOCK = K + 1
+PEER_SLICES = [[0, 1, 2, 3], [4, 5]]
+LOCAL_SCEN_IDXS = [2, 3, 4, 5]
+NSCEN_LOCAL = len(LOCAL_SCEN_IDXS)
+BEST_XHAT_LEN = NSCEN_LOCAL * BLOCK          # one version's worth, this rank
+NVERSIONS = 2
+RECENT_LEN = NVERSIONS * BEST_XHAT_LEN
+
+# Distinct first-stage markers per (source rank, version); the gap between the
+# two ranks is what the NAC fix-up must erase.
+def _fs(rank, version):
+    return 0.5 + rank + 10.0 * version
+
+# Per-scenario, per-version cost; never touched by the fix-up.
+def _cost(scen, version):
+    return 1000.0 * version + scen
+
+
+def _make_stub():
+    sp = types.SimpleNamespace()
+    sp.opt = types.SimpleNamespace(nonant_length=K)
+    sp._local_scen_idxs = list(LOCAL_SCEN_IDXS)
+    sp._field_lengths = {
+        Field.BEST_XHAT: BEST_XHAT_LEN,
+        Field.RECENT_XHATS: RECENT_LEN,
+    }
+    return sp
+
+
+def _make_source_buffer(scens_on_rank, rank, nversions):
+    """A peer rank's send buffer for a BEST_XHAT-style field: nversions copies of
+    [block per scenario], each block = [first-stage(K), cost]."""
+    per_version = len(scens_on_rank) * BLOCK
+    buf = np.full(nversions * per_version, np.nan)
+    for v in range(nversions):
+        for j, s in enumerate(scens_on_rank):
+            off = v * per_version + j * BLOCK
+            buf[off:off + K] = _fs(rank, v)
+            buf[off + K] = _cost(s, v)
+    return buf
+
+
+def _assemble(segments, sources, local_len):
+    """Mirror the segment-copy loop in _flex_get_multi_source (no MPI)."""
+    local_buf = np.full(local_len, np.nan)
+    for seg in segments:
+        src = sources[seg.remote_rank]
+        local_buf[seg.local_offset:seg.local_offset + seg.count] = \
+            src[seg.remote_offset:seg.remote_offset + seg.count]
+    return local_buf
+
+
+class TestFlexXhatAssembly(unittest.TestCase):
+
+    def test_expand_circular_versions_offsets(self):
+        """The expanded segments must carry a per-rank version stride."""
+        sp = _make_stub()
+        items_per_scen = [BLOCK] * 6
+        base_segments = compute_overlap_segments(
+            LOCAL_SCEN_IDXS, PEER_SLICES, items_per_scen
+        )
+        # base = 0 here, so remote_rank is already the (global) source rank.
+        expanded = SPCommunicator._expand_to_circular_versions(
+            sp, base_segments, PEER_SLICES, 0, items_per_scen
+        )
+        got = {(s.remote_rank, s.remote_offset, s.local_offset, s.count)
+               for s in expanded}
+        # rank 0 version stride = 4*3 = 12; rank 1 version stride = 2*3 = 6;
+        # local version stride = 4*3 = 12.
+        expected = {
+            # version 0
+            (0, 6, 0, 6),    # scen 2,3 from rank0 (offset 2*3=6), into local 0
+            (1, 0, 6, 6),    # scen 4,5 from rank1 (offset 0),     into local 6
+            # version 1: +12 remote on rank0, +6 remote on rank1, +12 local
+            (0, 18, 12, 6),
+            (1, 6, 18, 6),
+        }
+        self.assertEqual(got, expected)
+
+    def test_recent_xhats_assembly_and_nac_fixup(self):
+        """Version-interleaved assembly + per-version first-stage NAC fix-up."""
+        sp = _make_stub()
+        items_per_scen = [BLOCK] * 6
+        base_segments = compute_overlap_segments(
+            LOCAL_SCEN_IDXS, PEER_SLICES, items_per_scen
+        )
+        expanded = SPCommunicator._expand_to_circular_versions(
+            sp, base_segments, PEER_SLICES, 0, items_per_scen
+        )
+        sources = {
+            0: _make_source_buffer(PEER_SLICES[0], 0, NVERSIONS),
+            1: _make_source_buffer(PEER_SLICES[1], 1, NVERSIONS),
+        }
+        local_buf = _assemble(expanded, sources, RECENT_LEN)
+
+        # Before the fix-up: scen 2,3 carry rank-0's first stage, scen 4,5
+        # rank-1's -- inconsistent across scenarios (this is what the fix-up
+        # must repair). Costs are already correctly routed per scenario.
+        self.assertEqual(local_buf[0], _fs(0, 0))    # local scen 2, v0
+        self.assertEqual(local_buf[6], _fs(1, 0))    # local scen 4, v0
+
+        SPCommunicator._enforce_first_stage_nac(sp, local_buf, Field.RECENT_XHATS)
+
+        # After: every scenario's first stage equals scenario-0's source
+        # (rank 0), per version; costs untouched and per-scenario.
+        expected = np.empty(RECENT_LEN)
+        for v in range(NVERSIONS):
+            ref = _fs(0, v)  # rank 0 holds local scenario 0 (global 2)
+            for j, s in enumerate(LOCAL_SCEN_IDXS):
+                off = v * BEST_XHAT_LEN + j * BLOCK
+                expected[off:off + K] = ref
+                expected[off + K] = _cost(s, v)
+        np.testing.assert_allclose(local_buf, expected)
+
+    def test_best_xhat_single_version_nac_fixup(self):
+        """BEST_XHAT is the one-version case of the same fix-up."""
+        sp = _make_stub()
+        items_per_scen = [BLOCK] * 6
+        segments = compute_overlap_segments(
+            LOCAL_SCEN_IDXS, PEER_SLICES, items_per_scen
+        )
+        sources = {
+            0: _make_source_buffer(PEER_SLICES[0], 0, 1),
+            1: _make_source_buffer(PEER_SLICES[1], 1, 1),
+        }
+        local_buf = _assemble(segments, sources, BEST_XHAT_LEN)
+        SPCommunicator._enforce_first_stage_nac(sp, local_buf, Field.BEST_XHAT)
+
+        expected = np.empty(BEST_XHAT_LEN)
+        ref = _fs(0, 0)
+        for j, s in enumerate(LOCAL_SCEN_IDXS):
+            off = j * BLOCK
+            expected[off:off + K] = ref
+            expected[off + K] = _cost(s, 0)
+        np.testing.assert_allclose(local_buf, expected)
+
+    def test_xfeas_is_not_collapsed(self):
+        """XFEAS carries per-scenario distinct iterates: assembled per scenario,
+        with NO NAC fix-up, so each scenario keeps its own first stage."""
+        items_per_scen = [BLOCK] * 6
+        segments = compute_overlap_segments(
+            LOCAL_SCEN_IDXS, PEER_SLICES, items_per_scen
+        )
+        sources = {
+            0: _make_source_buffer(PEER_SLICES[0], 0, 1),
+            1: _make_source_buffer(PEER_SLICES[1], 1, 1),
+        }
+        local_buf = _assemble(segments, sources, BEST_XHAT_LEN)
+        # No _enforce_first_stage_nac call: XFEAS is not in _FIRST_STAGE_NAC_FIELDS.
+
+        expected = np.empty(BEST_XHAT_LEN)
+        for j, s in enumerate(LOCAL_SCEN_IDXS):
+            holding_rank = 0 if s in PEER_SLICES[0] else 1
+            off = j * BLOCK
+            expected[off:off + K] = _fs(holding_rank, 0)
+            expected[off + K] = _cost(s, 0)
+        np.testing.assert_allclose(local_buf, expected)
+        # And the two source ranks really did differ (so the test is meaningful).
+        self.assertNotEqual(_fs(0, 0), _fs(1, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_cli.py
+++ b/mpisppy/tests/test_flexible_rank_cli.py
@@ -1,0 +1,101 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""The flexible-rank CLI flags (--<spoke>-rank-ratio) are declared with their
+spokes and flow through build_spoke_list onto each spoke dict's rank_ratio key,
+which WheelSpinner reads. Serial; no MPI."""
+
+import unittest
+
+from mpisppy.utils import config
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.generic.spokes import build_spoke_list
+
+
+def _full_cfg():
+    # Declare the same arg set the generic driver does (the subset that
+    # build_spoke_list reads), so every cfg flag it touches exists.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.fwph_args()
+    cfg.lagrangian_args()
+    cfg.gapper_args("lagrangian")
+    cfg.ph_dual_args()
+    cfg.relaxed_ph_args()
+    cfg.ph_xfeas_spoke_args()
+    cfg.subgradient_args()
+    cfg.subgradient_bounder_args()
+    cfg.xhatshuffle_args()
+    cfg.xhatxbar_args()
+    cfg.reduced_costs_args()
+    cfg.sep_rho_args()
+    cfg.coeff_rho_args()
+    cfg.sensi_rho_args()
+    cfg.gradient_args()
+    cfg.gapper_args()
+    return cfg
+
+
+class TestFlexibleRankCLI(unittest.TestCase):
+
+    def test_rank_ratio_args_default_to_one(self):
+        cfg = _full_cfg()
+        self.assertEqual(cfg.lagrangian_rank_ratio, 1.0)
+        self.assertEqual(cfg.xhatshuffle_rank_ratio, 1.0)
+        self.assertEqual(cfg.xhatxbar_rank_ratio, 1.0)
+
+    def test_build_spoke_list_injects_rank_ratio(self):
+        cfg = _full_cfg()
+        cfg.num_scens = 6
+        cfg.lagrangian = True
+        cfg.lagrangian_rank_ratio = 0.5
+        cfg.xhatshuffle = True
+        cfg.xhatshuffle_rank_ratio = 0.25
+        cfg.xhatxbar = True
+        cfg.xhatxbar_rank_ratio = 2.0
+
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(cfg)
+        beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+        spokes = build_spoke_list(
+            cfg, beans, scenario_creator_kwargs,
+            rho_setter=None, all_nodenames=None,
+        )
+
+        # exactly the three enabled spokes, each carrying its requested ratio
+        ratios = sorted(d["rank_ratio"] for d in spokes)
+        self.assertEqual(ratios, sorted([0.5, 0.25, 2.0]))
+        # and every spoke dict got an explicit rank_ratio
+        self.assertTrue(all("rank_ratio" in d for d in spokes))
+
+    def test_default_run_leaves_ratios_at_one(self):
+        # With no ratios set, enabled spokes default to 1.0 (equal-rank path).
+        cfg = _full_cfg()
+        cfg.num_scens = 6
+        cfg.xhatshuffle = True
+        scenario_creator = farmer.scenario_creator
+        scenario_denouement = farmer.scenario_denouement
+        all_scenario_names = farmer.scenario_names_creator(cfg.num_scens)
+        scenario_creator_kwargs = farmer.kw_creator(cfg)
+        beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+        spokes = build_spoke_list(
+            cfg, beans, scenario_creator_kwargs,
+            rho_setter=None, all_nodenames=None,
+        )
+        self.assertEqual([d["rank_ratio"] for d in spokes], [1.0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/tests/test_flexible_rank_xhat.py
+++ b/mpisppy/tests/test_flexible_rank_xhat.py
@@ -1,0 +1,150 @@
+###############################################################################
+# mpi-sppy: MPI-based Stochastic Programming in PYthon
+#
+# Copyright (c) 2024, Lawrence Livermore National Security, LLC, Alliance for
+# Sustainable Energy, LLC, The Regents of the University of California, et al.
+# All rights reserved. Please see the files COPYRIGHT.md and LICENSE.md for
+# full copyright and license information.
+###############################################################################
+"""End-to-end integration test for the unequal-rank xhat fields (Phase 4a).
+
+Runs farmer with an FWPH hub and an xhatshuffle (inner-bound) spoke at *unequal*
+rank counts. This exercises the Category-2 xhat fields the earlier phases did
+not:
+
+  * the xhatshuffle spoke sends BEST_XHAT and RECENT_XHATS, which the FWPH hub
+    assembles across the spoke's ranks -- multi-source per-scenario blocks plus
+    the first-stage NAC fix-up, and (for RECENT_XHATS) version-aware assembly of
+    the circular buffer;
+  * the FWPH hub still sends NONANTS_VALS to the spoke (the Phase-2 path), so the
+    two cylinders genuinely run at different rank counts in both directions.
+
+A torn read, a misrouted segment, a broken first-stage fix-up, or wrong version
+interleaving would feed FWPH garbage columns -- the hub's outer bound would stop
+tracking the extensive-form optimum or the directions would disagree. We pin
+correctness with the same two-directional / ground-truth pattern as
+test_flexible_rank_cylinders, using fullcomm windows in both directions:
+
+  * 4+2 vs 2+4: hub larger than spoke and vice versa (opposite asymmetry, so a
+    hub rank stitches several spoke buffers in one direction and reads a
+    sub-range of one in the other);
+  * both must bracket and approach the extensive-form optimum (ground truth).
+
+mpiexec -np 6 python -m mpi4py -m pytest mpisppy/tests/test_flexible_rank_xhat.py
+"""
+
+import unittest
+
+from mpi4py import MPI
+
+from mpisppy.utils import config
+import mpisppy.utils.cfg_vanilla as vanilla
+import mpisppy.tests.examples.farmer as farmer
+from mpisppy.spin_the_wheel import WheelSpinner
+from mpisppy.tests.utils import get_solver
+
+comm = MPI.COMM_WORLD
+
+solver_available, solver_name, persistent_available, persistent_solver_name = get_solver()
+
+# Extensive-form optimum for farmer with NUM_SCENS=10 (a deterministic LP
+# optimum, solver-independent); see test_flexible_rank_cylinders.
+EF_OPT = -122146.70
+
+
+def _build_dicts(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    # Fresh cfg/dicts per run: WheelSpinner.run mutates the dicts and may only
+    # run once, so each run needs its own.
+    cfg = config.Config()
+    cfg.num_scens_required()
+    cfg.popular_args()
+    cfg.two_sided_args()
+    cfg.ph_args()
+    cfg.fwph_args()
+    cfg.xhatshuffle_args()
+    cfg.solver_name = solver_name
+    cfg.num_scens = num_scens
+    cfg.default_rho = 1.0
+    cfg.max_iterations = max_iterations
+    cfg.rel_gap = 1e-6
+
+    scenario_creator = farmer.scenario_creator
+    scenario_denouement = farmer.scenario_denouement
+    all_scenario_names = farmer.scenario_names_creator(num_scens)
+    scenario_creator_kwargs = farmer.kw_creator(cfg)
+    beans = (cfg, scenario_creator, scenario_denouement, all_scenario_names)
+
+    hub_dict = vanilla.fwph_hub(*beans, scenario_creator_kwargs=scenario_creator_kwargs)
+    hub_dict["rank_ratio"] = hub_ratio
+
+    xhatshuffle_spoke = vanilla.xhatshuffle_spoke(
+        *beans, scenario_creator_kwargs=scenario_creator_kwargs
+    )
+    xhatshuffle_spoke["rank_ratio"] = spoke_ratio
+
+    return hub_dict, [xhatshuffle_spoke]
+
+
+def _run(num_scens, max_iterations, hub_ratio, spoke_ratio):
+    hub_dict, spoke_list = _build_dicts(
+        num_scens, max_iterations, hub_ratio, spoke_ratio
+    )
+    wheel = WheelSpinner(hub_dict, spoke_list)
+    wheel.spin()
+    # Bounds are populated on the hub's base rank (global rank 0); broadcast so
+    # every rank can assert in lockstep.
+    if wheel.global_rank == 0:
+        payload = (wheel.BestInnerBound, wheel.BestOuterBound)
+    else:
+        payload = None
+    return comm.bcast(payload, root=0)
+
+
+@unittest.skipUnless(comm.size == 6, "needs exactly 6 MPI ranks")
+@unittest.skipUnless(solver_available, "no solver is available")
+class TestFlexibleRankXhat(unittest.TestCase):
+
+    NUM_SCENS = 10
+    MAX_ITERS = 25
+
+    def test_fwph_hub_unequal_ranks_both_directions(self):
+        # 4-rank hub, 2-rank spoke: each hub rank stitches the spoke's
+        # BEST_XHAT/RECENT_XHATS from several spoke buffers (multi-segment).
+        ib_42, ob_42 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 0.5)
+        # 2-rank hub, 4-rank spoke: each hub rank reads a sub-range of one
+        # spoke buffer (the other asymmetry direction).
+        ib_24, ob_24 = _run(self.NUM_SCENS, self.MAX_ITERS, 1.0, 2.0)
+
+        # Finite bounds (a torn/garbage read would give inf or error out).
+        for b in (ib_42, ob_42, ib_24, ob_24):
+            self.assertTrue(abs(b) < float("inf"))
+
+        # FWPH's outer bound is its master LP bound, fed by the assembled xhat
+        # columns; the two asymmetry directions must agree closely.
+        self.assertLess(
+            abs(ob_42 - ob_24), 1e-2 * abs(ob_42),
+            msg=f"4+2 outer bound {ob_42} disagrees with 2+4 {ob_24}",
+        )
+
+        for ib, ob in ((ib_42, ob_42), (ib_24, ob_24)):
+            # Minimizing farmer: outer bound is a lower bound (<= opt), inner
+            # bound (incumbent) is an upper bound (>= opt). The outer bound is
+            # FWPH's deterministic master LP bound, checked tightly (1%); the
+            # incumbent comes from the (order-sensitive) xhatshuffle spoke, so
+            # it gets a looser 2% near-optimal check.
+            self.assertLessEqual(ob, EF_OPT + 1e-2 * abs(EF_OPT))
+            self.assertGreaterEqual(ib, EF_OPT - 1e-2 * abs(EF_OPT))
+            self.assertLess(
+                abs(ob - EF_OPT), 1e-2 * abs(EF_OPT),
+                msg=f"outer bound {ob} is not near the EF optimum {EF_OPT}",
+            )
+            self.assertLess(
+                abs(ib - EF_OPT), 2e-2 * abs(EF_OPT),
+                msg=f"inner bound {ib} is not near the EF optimum {EF_OPT}",
+            )
+            # Valid bracketing.
+            self.assertLessEqual(ob, ib + 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mpisppy/utils/config.py
+++ b/mpisppy/utils/config.py
@@ -745,6 +745,13 @@ class Config(pyofig.ConfigDict):
                               domain=bool,
                               default=False)
 
+        self.add_to_config('lagrangian_rank_ratio',
+                              description="MPI ranks for the lagrangian spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
+
         self.add_solver_specs("lagrangian")
         self.add_mipgap_specs("lagrangian")
 
@@ -971,6 +978,13 @@ class Config(pyofig.ConfigDict):
                            domain=bool,
                            default=False)
 
+        self.add_to_config('xhatshuffle_rank_ratio',
+                           description="MPI ranks for the xhatshuffle spoke "
+                                       "relative to the hub (flexible rank "
+                                       "assignments; default 1.0 = equal)",
+                           domain=float,
+                           default=1.0)
+
         self.add_to_config('add_reversed_shuffle',
                            description="using also the reversed shuffling (multistage only, default True)",
                            domain=bool,
@@ -1069,6 +1083,13 @@ class Config(pyofig.ConfigDict):
                               description="have an xhatxbar spoke",
                               domain=bool,
                               default=False)
+
+        self.add_to_config('xhatxbar_rank_ratio',
+                              description="MPI ranks for the xhatxbar spoke "
+                                          "relative to the hub (flexible rank "
+                                          "assignments; default 1.0 = equal)",
+                              domain=float,
+                              default=1.0)
 
         self.add_to_config('xhatxbar_try_jensens_first',
                            description="before entering the xhatxbar main loop, solve "

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -146,6 +146,9 @@ run_phase "test_flex_coherence_policy (serial)" \
 run_phase "test_flexible_rank_cli (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_cli.py -v
 
+run_phase "test_flex_xhat_assembly (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flex_xhat_assembly.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 
@@ -198,6 +201,9 @@ run_phase "test_flexible_rank_cylinders (mpiexec -np 6)" \
 
 run_phase "test_flexible_rank_duals (mpiexec -np 6)" \
     mpiexec -np 6 $OVERSUBSCRIBE coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_duals.py
+
+run_phase "test_flexible_rank_xhat (mpiexec -np 6)" \
+    mpiexec -np 6 -oversubscribe coverage run --rcfile="$PROJ_DIR/.coveragerc" -m mpi4py mpisppy/tests/test_flexible_rank_xhat.py
 
 # ---------- Tests that spawn mpiexec internally ----------
 

--- a/run_coverage.bash
+++ b/run_coverage.bash
@@ -143,6 +143,9 @@ run_phase "test_flexible_rank_ratios (serial)" \
 run_phase "test_flex_coherence_policy (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flex_coherence_policy.py -v
 
+run_phase "test_flexible_rank_cli (serial)" \
+    coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_flexible_rank_cli.py -v
+
 run_phase "test_xhat_from_file (serial)" \
     coverage run --rcfile=.coveragerc -m pytest mpisppy/tests/test_xhat_from_file.py -v
 


### PR DESCRIPTION
> **📚 Stacked PRs — flexible rank assignments**
> Reviewed and merged bottom-up; each PR targets the one below it.
>
> 1. **Pyomo/mpi-sppy#725 — Phase 1: infrastructure** — ✅ merged
> 2. **Pyomo/mpi-sppy#731 — Phase 2: communication layer** — ✅ merged
> 3. **Pyomo/mpi-sppy#736 — Phase 3a: per-field coherence (DUALS strict)** (targets `main`)
> 4. **DLWoodruff/mpi-sppy-1#14 — Phase 3b: CLI rank-ratio flags** (targets `flex-ranks-phase3-coherence`)
> 5. **DLWoodruff/mpi-sppy-1#15 — Phase 4a: two-stage xhat fields** (targets `flex-ranks-phase3b-cli`) ← _this PR_
>
> 6. **DLWoodruff/mpi-sppy-1#16 — Phase 4b: multistage per-node xhat sourcing** (targets `flex-ranks-phase4a-xhat-2stage`)
> 7. **DLWoodruff/mpi-sppy-1#17 — Phase 5: APH (asynchronous sender) verification** (targets `flex-ranks-phase4b-multistage`)
>
> _Later phases will be appended here as they open._

---

Adds multi-source assembly for the **Category-2 xhat fields** —
`BEST_XHAT`, `RECENT_XHATS`, `XFEAS` — across cylinders with unequal rank
counts, for **two-stage** problems. These are the fields consumed by the FWPH
and CG hubs from inner-bound / xhat-feasible spokes; until now reading them at a
non-default rank ratio hit the phase-3b `NotImplementedError` guard at startup.

## What's here (`mpisppy/cylinders/spcommunicator.py`)

- **`_items_per_scen_for_field`** now treats these fields as per-scenario
  `[first-stage nonants, cost]` blocks (`nonant_length + 1` items/scenario). It
  raises a clear `NotImplementedError` under `opt.multistage` — per-node
  first-stage sourcing is **phase 4b**.
- **First-stage NAC fix-up (`_enforce_first_stage_nac`).** `BEST_XHAT` /
  `RECENT_XHATS` carry an incumbent first stage that is identical across
  scenarios by non-anticipativity, but multi-source assembly fills each
  scenario's block from the rank that holds it (possibly at different
  `write_id`s). After assembly we overwrite every scenario's first-stage portion
  with **scenario-0's block** — which arrived whole from a single rank, so it is
  internally coherent — per version. The per-scenario **cost** slot is left
  alone (genuinely per-scenario). This realizes the design's "single-source
  first stage, per-scenario cost" by reusing the tested phase-2 assembler plus a
  small fix-up rather than a separate code path.
- **`XFEAS` is Category-1, not in `_FIRST_STAGE_NAC_FIELDS`.** It carries
  per-scenario *distinct* iterates (its CG consumer tries each scenario's `x` as
  its own candidate), so it is assembled per-scenario with **no** fix-up.
- **`RECENT_XHATS` circular buffer (`_expand_to_circular_versions`).** The
  buffer holds `V` versions, each a `BEST_XHAT`-sized per-scenario block. The
  single-version overlap segments are replicated across all `V` versions, with a
  **per-rank** remote version stride (the version size scales with each rank's
  local scenario count, so it differs between source ranks). The physical slots
  are copied faithfully, so the receiver's `RecvCircularBuffer` interprets the
  `write_id` exactly as on the equal-rank path.

Coherence stays **relaxed** for all three (they are not in
`_STRICT_COHERENCE_FIELDS`); the NAC fix-up is what keeps the first stage
consistent, not strict `write_id` agreement.

## Tests (wired into `run_coverage.bash` and `test_pr_and_main.yml`)

- **`test_flexible_rank_xhat.py`** — np=6 `FWPHHub` + xhatshuffle spoke at
  **4+2 and 2+4**. The FWPH hub assembles `BEST_XHAT`/`RECENT_XHATS` across the
  spoke's ranks (and still sends `NONANTS_VALS` to it). Both directions must
  agree on FWPH's (deterministic) outer bound and bracket/approach the EF
  optimum. A torn read, misrouted segment, broken fix-up, or wrong version
  interleaving would break this.
- **`test_flex_xhat_assembly.py`** — serial, exact-value: the per-rank version
  stride offsets, the NAC fix-up collapsing deliberately-mismatched first stages
  to scenario-0's, and `XFEAS` being left per-scenario. (Runs in CI, unlike the
  np=6 MPI test on a stacked PR.)

Regression: np=2 `test_with_cylinders` and the existing np=6 flex tests
(`test_spwindow_multisource`, `test_flexible_rank_cylinders`,
`test_flexible_rank_duals`) stay green; `ruff` clean.

## Deferred

The **CG-hub `XFEAS` integration test** is deferred: a CG hub with **more than
one rank** deadlocks at convergence — `best_solution_obj_val` is set only on
`cylinder_rank 0` in `cgbase.iterk_loop` and (unlike `best_bound_obj_val`) never
broadcast, so `is_converged` diverges across hub ranks. This is **pre-existing**
and orthogonal to this reader (CG is only exercised at np=2 = 1 rank/cylinder
today; flexible ranks is the first multi-rank CG hub). Filed as
**Pyomo/mpi-sppy#729**. `XFEAS` is covered here by the serial assembly test; the
CG integration test and the `--ph-xfeas-spoke-rank-ratio` CLI flag will land in a
follow-up once #729 is fixed (tracked in Pyomo/mpi-sppy#730). No new CLI flag is
added for `ph_xfeas` here for the same reason (its only consumer is that CG hub).

Stacked on #14; gets no CI until retargeted to `main` (validated with local
`ruff`, serial tests, the two np=6 MPI tests with `-oversubscribe`, and the np=2
`test_with_cylinders` regression).




